### PR TITLE
Remove promotional, redundant, and stale code comments

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -16,10 +16,6 @@ pause
 exit /b %errorlevel%
 
 # __START_POWERSHELL__
-# ==============================================================================
-# Project Zomboid Build 42 - Config & Engine Optimizer (PZO)
-# Native PowerShell Engine Installer & Uninstaller
-# ==============================================================================
 
 Write-Host "=================================================================" -ForegroundColor Cyan
 Write-Host " Project Zomboid Build 42 Engine Optimizer (v0.9.6)" -ForegroundColor Cyan
@@ -35,7 +31,6 @@ $ZomboidLuaDir     = [System.IO.Path]::Combine($HOME, "Zomboid\Lua")
 $PzoStatusFile     = [System.IO.Path]::Combine($ZomboidLuaDir, "pzo_status.json")
 $ZomboidModsDir    = [System.IO.Path]::Combine($HOME, "Zomboid\mods")
 
-# Guard against game running
 $runningPZ = Get-Process -Name "ProjectZomboid64", "ProjectZomboid32" -ErrorAction SilentlyContinue
 if ($runningPZ) {
     Write-Host "`n[!] Warning: Project Zomboid is currently running." -ForegroundColor Yellow
@@ -51,9 +46,6 @@ if (-not (Test-Path -LiteralPath $ZomboidModsDir -ErrorAction SilentlyContinue))
     New-Item -ItemType Directory -Path $ZomboidModsDir -Force | Out-Null
 }
 
-# ==========================================
-# JSON TEMPLATES (Defined upfront - No BOM)
-# ==========================================
 $Json5OrLess = @"
 {
     "mainClass": "com/pzoptimizer/PZOEntrypoint",
@@ -347,7 +339,6 @@ $InstalledDllPath = [System.IO.Path]::Combine($InstallPath, $NativeDllName)
 $TargetFilePath   = [System.IO.Path]::Combine($InstallPath, $TargetFileName)
 $BackupDir        = [System.IO.Path]::Combine($InstallPath, $BackupFolder)
 
-# Locate Source Jar
 $candidateJarPaths = [System.Collections.Generic.List[string]]::new()
 if ($ScriptDir) {
     $candidateJarPaths.Add([System.IO.Path]::Combine($ScriptDir, $JarFileName))
@@ -376,7 +367,6 @@ if ($SourceJar) {
     }
 }
 
-# Locate Source Native DLL (pzo_native64.dll)
 $candidateDllPaths = [System.Collections.Generic.List[string]]::new()
 if ($ScriptDir) {
     $candidateDllPaths.Add([System.IO.Path]::Combine($ScriptDir, $NativeDllName))
@@ -406,9 +396,6 @@ if ($SourceDll) {
     }
 }
 
-# ==========================================
-# ZOMBIEBUDDY COEXISTENCE & PRESERVATION
-# ==========================================
 $zbNativeDll = [System.IO.Path]::Combine($InstallPath, "zbNative.dll")
 $zbNativeWin64 = [System.IO.Path]::Combine($InstallPath, "win64\zbNative.dll")
 $hasZbInJson = $false
@@ -425,7 +412,6 @@ if ($isZombieBuddyActive) {
     Write-Host "`n[+] ZombieBuddy detected! Coexistence mode enabled (preserving -agentlib:zbNative)." -ForegroundColor Green
 }
 
-# Check for Zed Better FPS NG conflict / redundancy
 $zbFpsWorkshop = [System.IO.Path]::Combine($InstallPath, "..\..\workshop\content\108600\3793137588")
 $zbFpsMods = [System.IO.Path]::Combine($env:USERPROFILE, "Zomboid\mods\ZBBetterFPSNG")
 if ((Test-Path -LiteralPath $zbFpsWorkshop) -or (Test-Path -LiteralPath $zbFpsMods)) {
@@ -481,12 +467,10 @@ function Apply-PZOConfiguration {
         $UseG1GC = $true
     }
 
-    # Inject native JVMTI agent bridge (-agentlib:pzo_native64) for bytecode instrumentation & ZombieBuddy coexistence
     if ($chosenJson -notmatch "pzo_native64") {
         $chosenJson = $chosenJson.Replace('"vmArgs": [', '"vmArgs": [' + "`n        " + '"-agentlib:pzo_native64",')
     }
 
-    # If ZombieBuddy is active, preserve -agentlib:zbNative seamlessly in vmArgs
     if ($isZombieBuddyActive -and ($chosenJson -notmatch "zbNative")) {
         $chosenJson = $chosenJson.Replace('"vmArgs": [', '"vmArgs": [' + "`n        " + '"-agentlib:zbNative",')
     }
@@ -517,9 +501,6 @@ function Apply-PZOConfiguration {
     Write-Host "Generated Lua bridge status: $PzoStatusFile" -ForegroundColor Green
 }
 
-# ==========================================
-# EXISTING INSTALLATION CHECK (UPDATE / UNINSTALL)
-# ==========================================
 if (Test-Path $InstalledJarPath) {
     Write-Host "`n[!] PZOptimEngine is already installed." -ForegroundColor Yellow
     Write-Host "1) Update    - Overwrite PZOptimEngine.jar with the new version & refresh config [Default]"
@@ -582,14 +563,12 @@ if (Test-Path $InstalledJarPath) {
                 Write-Host "Removed: win64\$NativeDllName" -ForegroundColor Green
             }
 
-            # Purge all pzo_* bridge, telemetry, log and status files from ~/Zomboid/Lua/
             if (Test-Path -LiteralPath $ZomboidLuaDir -ErrorAction SilentlyContinue) {
                 Get-ChildItem -LiteralPath $ZomboidLuaDir -Filter "pzo_*" -File -ErrorAction SilentlyContinue | ForEach-Object {
                     Remove-Item -LiteralPath $_.FullName -Force -ErrorAction SilentlyContinue
                     Write-Host "Removed: $($_.Name)" -ForegroundColor Green
                 }
             }
-            # Clean up any leftover pzo files in root Zomboid or game directories
             $extraPzoPaths = @(
                 [System.IO.Path]::Combine($HOME, "Zomboid\pzo_status.json"),
                 [System.IO.Path]::Combine($HOME, "Zomboid\pzo_telemetry.json"),
@@ -627,9 +606,6 @@ if (Test-Path $InstalledJarPath) {
     }
 }
 
-# ==========================================
-# FRESH INSTALLATION
-# ==========================================
 Write-Host "`nStarting fresh installation..." -ForegroundColor Cyan
 
 if ($SourceJar -and (Test-Path -LiteralPath $SourceJar -ErrorAction SilentlyContinue)) {

--- a/native/pzo_native.c
+++ b/native/pzo_native.c
@@ -1,17 +1,3 @@
-/*
- * Project Zomboid Optimiser (PZO) - Native Kernel & Hardware Governor
- * Multi-Platform: Windows x64, Linux (x86_64 / AArch64), macOS (Apple Silicon / Intel)
- *
- * Implements OS-level kernel governors:
- *  - Windows: 0.5ms Interrupt Timer Resolution Lock (NtSetTimerResolution + timeBeginPeriod)
- *  - Windows: Windows 11 Power Throttling / EcoQoS Complete Exemption (SetProcessInformation)
- *  - Windows: Windows Multimedia Class Scheduler Service (MMCSS "Games" profile via Avrt)
- *  - POSIX (Linux/macOS): High-resolution monotonic timers, real-time thread priority & mlockall
- *  - Cross-Platform CPU Hybrid Topology Detection (P-Cores vs E-Cores / Thread Affinity)
- *  - AVX2 Vectorized SIMD Batch Spatial & Distance Processor (zero-copy NIO, scalar fallback for ARM64)
- *  - Low-latency miniz tinfl RFC 1950 zlib / raw deflate decompression
- */
-
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -70,7 +56,6 @@ typedef void* HANDLE;
 #include "miniz_tinfl.c"
 
 #ifdef _WIN32
-// Dynamically resolved ntdll functions for high-precision sub-millisecond timer
 typedef LONG (NTAPI *pfnNtSetTimerResolution)(ULONG DesiredResolution, BOOLEAN SetResolution, PULONG CurrentResolution);
 typedef LONG (NTAPI *pfnNtQueryTimerResolution)(PULONG MinimumResolution, PULONG MaximumResolution, PULONG CurrentResolution);
 
@@ -88,7 +73,6 @@ static pfnSetProcessInformation g_SetProcessInformation = NULL;
 static HANDLE g_mmcssTaskHandle = NULL;
 #endif
 
-// CPU Topology & State Cache
 static DWORD_PTR g_pCoreAffinityMask = 0;
 static int g_physicalCores = 0;
 static int g_pCoresCount = 0;
@@ -97,7 +81,6 @@ static BOOL g_avx2Supported = FALSE;
 static BOOL g_timerLocked = FALSE;
 static ULONG g_activeTimerResolution100ns = 10000;
 
-// Check AVX2 CPUID
 static BOOL checkCpuAvx2Support(void) {
 #if defined(_WIN32)
     int cpuInfo[4] = {0};
@@ -122,7 +105,6 @@ static BOOL checkCpuAvx2Support(void) {
 #endif
 }
 
-// Query CPU Topology: distinguishes Performance Cores (P-Cores) from Efficiency Cores (E-Cores)
 static void detectCpuTopology(void) {
 #if defined(_WIN32)
     DWORD length = 0;
@@ -149,7 +131,7 @@ static void detectCpuTopology(void) {
     int totalPhysical = 0;
     int totalLogical = 0;
 
-    // Pass 1: find highest efficiency class and count cores
+    // Find the highest efficiency class before collecting its affinity mask.
     BYTE* ptr = (BYTE*)buffer;
     BYTE* end = ptr + length;
     while (ptr < end) {
@@ -173,7 +155,6 @@ static void detectCpuTopology(void) {
     g_physicalCores = totalPhysical;
     g_logicalProcessors = totalLogical;
 
-    // Pass 2: gather affinity mask for highest efficiency class (P-cores)
     DWORD_PTR pCoreMask = 0;
     int pCoreCount = 0;
 
@@ -225,7 +206,6 @@ static void detectCpuTopology(void) {
     }
     g_pCoreAffinityMask = (g_logicalProcessors >= 64) ? ~(DWORD_PTR)0 : (((DWORD_PTR)1 << g_logicalProcessors) - 1);
 #else
-    // Linux
     g_logicalProcessors = (int)sysconf(_SC_NPROCESSORS_ONLN);
     if (g_logicalProcessors <= 0) g_logicalProcessors = 4;
     g_physicalCores = g_logicalProcessors;
@@ -234,7 +214,6 @@ static void detectCpuTopology(void) {
 #endif
 }
 
-// High Precision Interrupt Timer Lock
 static BOOL setHighPrecisionTimer(BOOL enable) {
 #if defined(_WIN32)
     if (enable) {
@@ -269,13 +248,12 @@ static BOOL setHighPrecisionTimer(BOOL enable) {
     }
 #else
     (void)enable;
-    g_activeTimerResolution100ns = 10000; // Sub-millisecond on POSIX
+    g_activeTimerResolution100ns = 10000;
     g_timerLocked = TRUE;
     return TRUE;
 #endif
 }
 
-// Complete Windows 11 Power Throttling / EcoQoS Exemption
 static BOOL disablePowerThrottling(void) {
 #if defined(_WIN32)
     if (g_SetProcessInformation) {
@@ -297,7 +275,6 @@ static BOOL disablePowerThrottling(void) {
 #endif
 }
 
-// Multimedia Class Scheduler / Audio Profile
 #if defined(_WIN32)
 static BOOL setMMCSSProfile(const wchar_t* profile) {
     DWORD taskIndex = 0;
@@ -316,7 +293,6 @@ static BOOL setMMCSSProfile(const char* profile) {
 }
 #endif
 
-// Process Priority Governor
 static BOOL setProcessPriority(int level) {
 #if defined(_WIN32)
     DWORD pClass = ABOVE_NORMAL_PRIORITY_CLASS;
@@ -333,7 +309,6 @@ static BOOL setProcessPriority(int level) {
 #endif
 }
 
-// P-Core Affinity Binding for Current Thread
 static BOOL bindCurrentThreadToPCores(void) {
 #if defined(_WIN32)
     if (g_pCoreAffinityMask != 0) {
@@ -356,7 +331,6 @@ static BOOL bindCurrentThreadToPCores(void) {
 #endif
 }
 
-// Complete Calling Thread Optimization
 #if defined(_WIN32)
 static BOOL optimizeCallingThread(int priorityLevel, BOOL bindPCores, const wchar_t* mmcssProfile) {
     HANDLE hThread = GetCurrentThread();
@@ -403,7 +377,6 @@ static BOOL optimizeCallingThread(int priorityLevel, BOOL bindPCores, const char
 }
 #endif
 
-// Working Set & Physical RAM Locking
 static BOOL lockProcessWorkingSet(void) {
 #if defined(_WIN32)
     SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS);
@@ -419,8 +392,7 @@ static BOOL lockProcessWorkingSet(void) {
         maxSize = (total > (SIZE_T)4 * 1024 * 1024 * 1024) ? (total * 3 / 4) : total;
     }
 
-    // Use soft working set expansion (flag 0) to ensure Windows kernel memory manager
-    // never stalls application threads with hard paging quota suspensions.
+    // Request a soft working-set expansion rather than enforcing hard quotas.
     return SetProcessWorkingSetSizeEx(GetCurrentProcess(), minSize, maxSize, 0);
 #elif defined(MCL_CURRENT)
     return (mlockall(MCL_CURRENT) == 0);
@@ -434,7 +406,6 @@ static BOOL lockProcessWorkingSet(void) {
 #pragma GCC target("avx2")
 #endif
 
-// AVX2 Vectorized 2D Distance Calculation (Zero-copy, 8 floats per SIMD instruction)
 static int batchCalculateDistancesAVX2(const float* coords, int count, float ox, float oy, float* outDistances) {
     if (!coords || !outDistances || count <= 0) return 0;
 
@@ -475,7 +446,6 @@ static int batchCalculateDistancesAVX2(const float* coords, int count, float ox,
     return count;
 }
 
-// AVX2 Vectorized 2D Squared Distance Calculation (Zero-copy, 8 floats per SIMD instruction, no sqrt)
 static int batchCalculateDistancesSqAVX2(const float* coords, int count, float ox, float oy, float* outDistSq) {
     if (!coords || !outDistSq || count <= 0) return 0;
 
@@ -514,7 +484,6 @@ static int batchCalculateDistancesSqAVX2(const float* coords, int count, float o
     return count;
 }
 
-// AVX2 Vectorized Radial Proximity Culling
 static int batchCullRadialAVX2(const float* coords, int count, float ox, float oy, float maxRadiusSq, unsigned char* outMask) {
     if (!coords || !outMask || count <= 0) return 0;
 
@@ -564,7 +533,6 @@ static int batchCullRadialAVX2(const float* coords, int count, float ox, float o
     return insideCount;
 }
 
-// AVX2 Vectorized 2D AABB / Screen Viewport Culling
 static int batchCullAABBAVX2(const float* coords, int count, float minX, float minY, float maxX, float maxY, unsigned char* outMask) {
     if (!coords || !outMask || count <= 0) return 0;
 
@@ -615,7 +583,6 @@ static int batchCullAABBAVX2(const float* coords, int count, float minX, float m
     return insideCount;
 }
 
-// AVX2 Vectorized Multi-Tier Distance Classification
 static int batchClassifyTiersAVX2(const float* coords, int count, float ox, float oy,
                                   float t0Sq, float t1Sq, float t2Sq, unsigned char* outTiers) {
     if (!coords || !outTiers || count <= 0) return 0;
@@ -676,8 +643,7 @@ static int batchClassifyTiersAVX2(const float* coords, int count, float ox, floa
     return count;
 }
 
-// AVX2 Vectorized Field-of-View & Line-of-Sight Visibility Engine
-// Tests 8 entities per cycle for range, directional dot-product, and FOV cone.
+// Tests range, heading dot product, and field-of-view angle in batches of eight.
 static int batchCalculateFovAVX2(
     const float* coords, const float* headings, int count,
     float targetX, float targetY, float viewDistSq, float cosHalfFov, float closeRadiusSq,
@@ -765,7 +731,6 @@ static int batchCalculateFovAVX2(
     return visibleCount;
 }
 
-// AVX2 Vectorized Crowd Separation & Repulsion Vector Engine
 // For each entity i, computes accumulated steering repulsion away from nearby entities.
 static int batchCalculateRepulsionAVX2(
     const float* coords, int count, float separationRadius, float maxForce, float* outForces) {
@@ -872,10 +837,6 @@ static int batchCalculateRepulsionAVX2(
 #pragma GCC pop_options
 #endif
 
-// ============================================================================
-// JNI Exports for com.pzoptimizer.PZONative
-// ============================================================================
-
 JNIEXPORT jboolean JNICALL Java_com_pzoptimizer_PZONative_initNative(JNIEnv *env, jclass cls) {
     (void)env; (void)cls;
 
@@ -891,7 +852,6 @@ JNIEXPORT jboolean JNICALL Java_com_pzoptimizer_PZONative_initNative(JNIEnv *env
         g_SetProcessInformation = (pfnSetProcessInformation)GetProcAddress(hKernel32, "SetProcessInformation");
     }
 
-    // Set NVIDIA & GPU multi-threaded driver optimizations
     SetEnvironmentVariableW(L"__GL_THREADED_OPTIMIZATIONS", L"1");
     SetEnvironmentVariableW(L"__GL_YIELD", L"NOTHING");
 #else
@@ -1086,10 +1046,6 @@ JNIEXPORT jint JNICALL Java_com_pzoptimizer_PZONative_batchCalculateRepulsionAVX
         inCoords, (int)count, (float)separationRadius, (float)maxForce, outForces
     );
 }
-
-// ============================================================================
-// Phase 2: High-Speed SIMD Decompression & Win32/POSIX Chunk Stream Acceleration
-// ============================================================================
 
 static jint decompressBuffer(const unsigned char *src, size_t srcLen, unsigned char *dst, size_t dstCap) {
     if (!src || !dst || srcLen == 0 || dstCap == 0) return -1;
@@ -1477,10 +1433,6 @@ JNIEXPORT jboolean JNICALL Java_com_pzoptimizer_PZONative_isDriveSSDNative(JNIEn
 #endif
 }
 
-/* ========================================================================= */
-/* JVMTI Native Agent Bridge (ZombieBuddy Architecture Bypass for javaagent)  */
-/* ========================================================================= */
-
 #define PZO_JAR "PZOptimEngine.jar"
 #define PZO_AGENT_OPTIONS_MAX 2048
 
@@ -1511,12 +1463,10 @@ static void init_instrument_dll(void) {
     if (g_hInstrument) return;
 
 #ifdef _WIN32
-    // 1. Try relative jre64\\bin directory
     SetDllDirectoryA(".\\jre64\\bin");
     g_hInstrument = LoadLibraryA("instrument.dll");
     SetDllDirectoryA(NULL);
 
-    // 2. Direct path fallbacks
     if (!g_hInstrument) {
         g_hInstrument = LoadLibraryA("jre64\\bin\\instrument.dll");
     }

--- a/package_release.py
+++ b/package_release.py
@@ -22,11 +22,9 @@ def find_file(fname, search_roots):
     for root_dir in search_roots:
         if not os.path.exists(root_dir):
             continue
-        # Direct check
         direct = os.path.join(root_dir, fname)
         if os.path.isfile(direct):
             return direct
-        # Recursive walk check
         for current, _, files in os.walk(root_dir):
             if fname in files:
                 return os.path.join(current, fname)
@@ -57,7 +55,6 @@ def main():
     print(f" Dist: {dist_dir}")
     print("================================================================================")
 
-    # 1. Build client and server JARs if not already present or out of date
     client_mf = os.path.join(src_dir, "META-INF", "MANIFEST.MF")
     server_mf = os.path.join(src_dir, "META-INF", "MANIFEST_SERVER.MF")
     client_jar = os.path.join(dist_dir, "PZOptimEngine.jar")
@@ -68,16 +65,13 @@ def main():
     if os.path.isdir(bin_dir) and os.path.isfile(server_mf):
         create_jar(bin_dir, server_mf, server_jar)
 
-    # Also copy to root if helpful
     if os.path.isfile(client_jar):
         shutil.copy2(client_jar, os.path.join(root_dir, "PZOptimEngine.jar"))
     if os.path.isfile(server_jar):
         shutil.copy2(server_jar, os.path.join(root_dir, "PZOServerEngine.jar"))
 
-    # Search locations for assets
     search_dirs = [dist_dir, native_dir, root_dir]
 
-    # 2. Gather standalone binaries & scripts for dist/
     files_to_copy = [
         "pzo_native64.dll",
         "libpzo_native64.so",
@@ -99,7 +93,6 @@ def main():
         else:
             print(f"[-] Optional asset not found (skipped): {fname}")
 
-    # 3. Package PZO-Optimizer-Windows.zip
     win_zip = os.path.join(dist_dir, "PZO-Optimizer-Windows.zip")
     with zipfile.ZipFile(win_zip, "w", zipfile.ZIP_DEFLATED) as zf:
         for f in ["install.bat", "PZOptimEngine.jar", "pzo_native64.dll", "README.md"]:
@@ -108,7 +101,6 @@ def main():
                 zf.write(fp, f)
     print(f"[+] Packaged: PZO-Optimizer-Windows.zip ({os.path.getsize(win_zip):,} bytes)")
 
-    # 4. Package PZO_Optimizer_macOS_Linux.zip
     mac_linux_zip = os.path.join(dist_dir, "PZO_Optimizer_macOS_Linux.zip")
     with zipfile.ZipFile(mac_linux_zip, "w", zipfile.ZIP_DEFLATED) as zf:
         for f in ["pzo_optimizer.sh", "pzo_optimizer.command", "PZOptimEngine.jar", "README.md", "libpzo_native64.so", "libpzo_native64.dylib"]:
@@ -117,7 +109,6 @@ def main():
                 zf.write(fp, f)
     print(f"[+] Packaged: PZO_Optimizer_macOS_Linux.zip ({os.path.getsize(mac_linux_zip):,} bytes)")
 
-    # 5. Package PZO-Server-Windows.zip
     srv_win_zip = os.path.join(dist_dir, "PZO-Server-Windows.zip")
     with zipfile.ZipFile(srv_win_zip, "w", zipfile.ZIP_DEFLATED) as zf:
         for f in ["PZOServerEngine.jar", "README_SERVER.md", "pzo_native64.dll"]:
@@ -126,7 +117,6 @@ def main():
                 zf.write(fp, f)
     print(f"[+] Packaged: PZO-Server-Windows.zip ({os.path.getsize(srv_win_zip):,} bytes)")
 
-    # 6. Package PZO-Server-Linux.zip
     srv_linux_zip = os.path.join(dist_dir, "PZO-Server-Linux.zip")
     with zipfile.ZipFile(srv_linux_zip, "w", zipfile.ZIP_DEFLATED) as zf:
         for f in ["PZOServerEngine.jar", "README_SERVER.md", "libpzo_native64.so"]:

--- a/pzo_optimizer.command
+++ b/pzo_optimizer.command
@@ -1,7 +1,4 @@
 #!/bin/bash
-# ==============================================================================
-# Project Zomboid Build 42 - Config & Engine Optimizer (macOS & Linux)
-# ==============================================================================
 
 set -e
 
@@ -14,7 +11,6 @@ OS_TYPE="$(uname -s)"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PZ_JAR=""
 
-# 1. Locate or Auto-Download PZOptimEngine.jar
 if [ -f "$SCRIPT_DIR/PZOptimEngine.jar" ]; then
     PZ_JAR="$SCRIPT_DIR/PZOptimEngine.jar"
 elif [ -f "$SCRIPT_DIR/dist/PZOptimEngine.jar" ]; then
@@ -49,7 +45,6 @@ fi
 
 echo "[+] Using engine package: $PZ_JAR"
 
-# 2. Detect Total RAM in GB
 TOTAL_RAM=8
 if [ "$OS_TYPE" = "Darwin" ]; then
     RAM_BYTES=$(sysctl -n hw.memsize 2>/dev/null || echo 8589934592)
@@ -73,7 +68,6 @@ fi
 RAM_MB=$((ALLOC_RAM * 1024))
 echo "[+] Detected $TOTAL_RAM GB System RAM -> Allocating $ALLOC_RAM GB (-Xmx${RAM_MB}m)"
 
-# Helper function to clean bridge files
 clean_lua_bridge_files() {
     LUA_DIR="$HOME/Zomboid/Lua"
     if [ -d "$LUA_DIR" ]; then
@@ -83,9 +77,6 @@ clean_lua_bridge_files() {
     rm -f "$HOME/Zomboid"/pzo_*
 }
 
-# ==============================================================================
-# macOS Native .app Bundle Installation
-# ==============================================================================
 if [ "$OS_TYPE" = "Darwin" ]; then
     echo "[*] Platform: macOS"
     POSSIBLE_APP_PATHS=(
@@ -124,7 +115,6 @@ if [ "$OS_TYPE" = "Darwin" ]; then
     INSTALLED_JAR="$JAVA_DIR/PZOptimEngine.jar"
     PLIST="$APP_BUNDLE/Contents/Info.plist"
 
-    # 3. Existing Installation Check (Update / Uninstall / Cancel)
     if [ -f "$INSTALLED_JAR" ]; then
         echo ""
         echo "[!] PZOptimEngine is already installed on macOS."
@@ -158,7 +148,6 @@ if [ "$OS_TYPE" = "Darwin" ]; then
         esac
     fi
 
-    # 4. Check for ZombieBuddy conflict on macOS
     ZB_FOUND=0
     if [ -f "$APP_BUNDLE/Contents/Java/ZombieBuddy.jar" ] || [ -f "$APP_BUNDLE/Contents/MacOS/zbNative.dylib" ] || [ -f "$APP_BUNDLE/Contents/Java/zbNative.dylib" ] || [ -f "$HOME/Library/Application Support/Steam/steamapps/common/ProjectZomboid/ZombieBuddy.jar" ]; then
         ZB_FOUND=1
@@ -175,7 +164,6 @@ if [ "$OS_TYPE" = "Darwin" ]; then
         echo "[+] ZombieBuddy detected! Coexistence mode enabled." 
     fi
 
-    # Check for Zed Better FPS NG conflict / redundancy
     if [ -d "$HOME/Zomboid/mods/ZBBetterFPSNG" ] || [ -d "$SCRIPT_DIR/../../workshop/content/108600/3793137588" ]; then
         echo ""
         echo "[!] NOTICE: Zed Better FPS NG detected in Workshop/Mods!"
@@ -186,12 +174,10 @@ if [ "$OS_TYPE" = "Darwin" ]; then
         echo ""
     fi
 
-    # 5. Install PZOptimEngine.jar to Contents/Java/
     mkdir -p "$JAVA_DIR"
     cp -f "$PZ_JAR" "$INSTALLED_JAR"
     echo "[+] Installed PZOptimEngine.jar -> $INSTALLED_JAR"
 
-    # Install libpzo_native64.dylib if present
     for dylib_c in "$SCRIPT_DIR/libpzo_native64.dylib" "$SCRIPT_DIR/dist/libpzo_native64.dylib" "$SCRIPT_DIR/../dist/libpzo_native64.dylib" "$SCRIPT_DIR/native/libpzo_native64.dylib"; do
         if [ -f "$dylib_c" ]; then
             cp -f "$dylib_c" "$JAVA_DIR/libpzo_native64.dylib"
@@ -202,7 +188,6 @@ if [ "$OS_TYPE" = "Darwin" ]; then
         fi
     done
 
-    # 6. Patch Contents/Info.plist
     if [ ! -f "$PLIST" ]; then
         echo "[!] Error: Contents/Info.plist not found in bundle."
         exit 1
@@ -225,7 +210,6 @@ with open(plist_path, "rb") as f:
 # Use dot notation for macOS Java launcher compatibility
 target_class_dot = "com.pzoptimizer.PZOEntrypoint"
 
-# Update Main Class across all known macOS launcher schema keys
 for key in ["JVMMainClassName", "MainClass", "JVMEntrypoint"]:
     if key in pl:
         pl[key] = target_class_dot
@@ -243,7 +227,6 @@ if "JVMOptions" in pl and isinstance(pl["JVMOptions"], dict):
     if "MainClass" in pl["JVMOptions"]:
         pl["JVMOptions"]["MainClass"] = target_class_dot
 
-# Ensure PZOptimEngine.jar is in ClassPath
 for cp_key in ["JVMClassPath", "ClassPath"]:
     if cp_key in pl:
         if isinstance(pl[cp_key], list):
@@ -297,9 +280,6 @@ EOF
         echo "[+] Successfully re-signed ProjectZomboid.app"
     fi
 
-# ==============================================================================
-# Linux Steam Installation
-# ==============================================================================
 else
     echo "[*] Platform: Linux"
 
@@ -332,7 +312,6 @@ else
     INSTALLED_JAR="$PZ_DIR/PZOptimEngine.jar"
     JSON_FILE="$PZ_DIR/ProjectZomboid64.json"
 
-    # Existing Installation Check on Linux
     if [ -f "$INSTALLED_JAR" ]; then
         echo ""
         echo "[!] PZOptimEngine is already installed on Linux."
@@ -366,7 +345,6 @@ else
         esac
     fi
 
-    # Check for ZombieBuddy conflict on Linux
     if [ -f "$PZ_DIR/ZombieBuddy.jar" ] || [ -f "$PZ_DIR/zbNative.so" ] || [ -f "$PZ_DIR/zbNative.dylib" ] || [ -f "$PZ_DIR/zombiebuddy.json" ]; then
         echo ""
         echo "========================================================================"
@@ -378,7 +356,6 @@ else
         echo "[+] ZombieBuddy detected! Coexistence mode enabled." 
     fi
 
-    # Check for Zed Better FPS NG conflict / redundancy
     if [ -d "$HOME/Zomboid/mods/ZBBetterFPSNG" ] || [ -d "$SCRIPT_DIR/../../workshop/content/108600/3793137588" ]; then
         echo ""
         echo "[!] NOTICE: Zed Better FPS NG detected in Workshop/Mods!"
@@ -389,11 +366,9 @@ else
         echo ""
     fi
 
-    # Copy JAR
     cp -f "$PZ_JAR" "$INSTALLED_JAR"
     echo "[+] Installed PZOptimEngine.jar -> $INSTALLED_JAR"
 
-    # Install libpzo_native64.so if present
     for so_c in "$SCRIPT_DIR/libpzo_native64.so" "$SCRIPT_DIR/dist/libpzo_native64.so" "$SCRIPT_DIR/../dist/libpzo_native64.so" "$SCRIPT_DIR/native/libpzo_native64.so"; do
         if [ -f "$so_c" ]; then
             cp -f "$so_c" "$PZ_DIR/libpzo_native64.so"
@@ -410,7 +385,6 @@ else
         echo "[+] Backed up original JSON config -> ${JSON_FILE}.bak"
     fi
 
-    # Safely update JSON while preserving existing classpath and libraries using Python
     python3 - << 'EOF' "$JSON_FILE" "$ALLOC_RAM" "$RAM_MB"
 import sys, json, os
 
@@ -426,10 +400,8 @@ if os.path.exists(json_file):
     except Exception:
         data = {}
 
-# Set optimized main entrypoint
 data["mainClass"] = "com/pzoptimizer/PZOEntrypoint"
 
-# Preserve existing classpath and ensure PZOptimEngine.jar is present
 cp = data.get("classpath", [])
 if not isinstance(cp, list):
     cp = []
@@ -439,7 +411,6 @@ if "." not in cp:
     cp.insert(0, ".")
 data["classpath"] = cp
 
-# Filter and update vmArgs
 existing_args = data.get("vmArgs", [])
 if not isinstance(existing_args, list):
     existing_args = []
@@ -455,7 +426,6 @@ for arg in existing_args:
         not arg.startswith("-XX:G1ReservePercent") and
         not arg.startswith("-XX:+PerfDisableSharedMem")):
         
-        # Automatically sanitize Windows library path if running on Linux
         if arg.startswith("-Djava.library.path="):
             if "win64" in arg:
                 arg = "-Djava.library.path=linux64/:natives/:."

--- a/pzo_optimizer.sh
+++ b/pzo_optimizer.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
-# ==============================================================================
-# Project Zomboid Build 42 - Config & Engine Optimizer (macOS & Linux)
-# ==============================================================================
 
 set -e
 
@@ -14,7 +11,6 @@ OS_TYPE="$(uname -s)"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PZ_JAR=""
 
-# 1. Locate or Auto-Download PZOptimEngine.jar
 if [ -f "$SCRIPT_DIR/PZOptimEngine.jar" ]; then
     PZ_JAR="$SCRIPT_DIR/PZOptimEngine.jar"
 elif [ -f "$SCRIPT_DIR/dist/PZOptimEngine.jar" ]; then
@@ -49,7 +45,6 @@ fi
 
 echo "[+] Using engine package: $PZ_JAR"
 
-# 2. Detect Total RAM in GB
 TOTAL_RAM=8
 if [ "$OS_TYPE" = "Darwin" ]; then
     RAM_BYTES=$(sysctl -n hw.memsize 2>/dev/null || echo 8589934592)
@@ -73,7 +68,6 @@ fi
 RAM_MB=$((ALLOC_RAM * 1024))
 echo "[+] Detected $TOTAL_RAM GB System RAM -> Allocating $ALLOC_RAM GB (-Xmx${RAM_MB}m)"
 
-# Helper function to clean bridge files
 clean_lua_bridge_files() {
     LUA_DIR="$HOME/Zomboid/Lua"
     if [ -d "$LUA_DIR" ]; then
@@ -83,9 +77,6 @@ clean_lua_bridge_files() {
     rm -f "$HOME/Zomboid"/pzo_*
 }
 
-# ==============================================================================
-# macOS Native .app Bundle Installation
-# ==============================================================================
 if [ "$OS_TYPE" = "Darwin" ]; then
     echo "[*] Platform: macOS"
     POSSIBLE_APP_PATHS=(
@@ -124,7 +115,6 @@ if [ "$OS_TYPE" = "Darwin" ]; then
     INSTALLED_JAR="$JAVA_DIR/PZOptimEngine.jar"
     PLIST="$APP_BUNDLE/Contents/Info.plist"
 
-    # 3. Existing Installation Check (Update / Uninstall / Cancel)
     if [ -f "$INSTALLED_JAR" ]; then
         echo ""
         echo "[!] PZOptimEngine is already installed on macOS."
@@ -158,7 +148,6 @@ if [ "$OS_TYPE" = "Darwin" ]; then
         esac
     fi
 
-    # 4. Check for ZombieBuddy conflict on macOS
     ZB_FOUND=0
     if [ -f "$APP_BUNDLE/Contents/Java/ZombieBuddy.jar" ] || [ -f "$APP_BUNDLE/Contents/MacOS/zbNative.dylib" ] || [ -f "$APP_BUNDLE/Contents/Java/zbNative.dylib" ] || [ -f "$HOME/Library/Application Support/Steam/steamapps/common/ProjectZomboid/ZombieBuddy.jar" ]; then
         ZB_FOUND=1
@@ -175,7 +164,6 @@ if [ "$OS_TYPE" = "Darwin" ]; then
         echo "[+] ZombieBuddy detected! Coexistence mode enabled." 
     fi
 
-    # Check for Zed Better FPS NG conflict / redundancy
     if [ -d "$HOME/Zomboid/mods/ZBBetterFPSNG" ] || [ -d "$SCRIPT_DIR/../../workshop/content/108600/3793137588" ]; then
         echo ""
         echo "[!] NOTICE: Zed Better FPS NG detected in Workshop/Mods!"
@@ -186,12 +174,10 @@ if [ "$OS_TYPE" = "Darwin" ]; then
         echo ""
     fi
 
-    # 5. Install PZOptimEngine.jar to Contents/Java/
     mkdir -p "$JAVA_DIR"
     cp -f "$PZ_JAR" "$INSTALLED_JAR"
     echo "[+] Installed PZOptimEngine.jar -> $INSTALLED_JAR"
 
-    # Install libpzo_native64.dylib if present
     for dylib_c in "$SCRIPT_DIR/libpzo_native64.dylib" "$SCRIPT_DIR/dist/libpzo_native64.dylib" "$SCRIPT_DIR/../dist/libpzo_native64.dylib" "$SCRIPT_DIR/native/libpzo_native64.dylib"; do
         if [ -f "$dylib_c" ]; then
             cp -f "$dylib_c" "$JAVA_DIR/libpzo_native64.dylib"
@@ -202,7 +188,6 @@ if [ "$OS_TYPE" = "Darwin" ]; then
         fi
     done
 
-    # 6. Patch Contents/Info.plist
     if [ ! -f "$PLIST" ]; then
         echo "[!] Error: Contents/Info.plist not found in bundle."
         exit 1
@@ -225,7 +210,6 @@ with open(plist_path, "rb") as f:
 # Use dot notation for macOS Java launcher compatibility
 target_class_dot = "com.pzoptimizer.PZOEntrypoint"
 
-# Update Main Class across all known macOS launcher schema keys
 for key in ["JVMMainClassName", "MainClass", "JVMEntrypoint"]:
     if key in pl:
         pl[key] = target_class_dot
@@ -243,7 +227,6 @@ if "JVMOptions" in pl and isinstance(pl["JVMOptions"], dict):
     if "MainClass" in pl["JVMOptions"]:
         pl["JVMOptions"]["MainClass"] = target_class_dot
 
-# Ensure PZOptimEngine.jar is in ClassPath
 for cp_key in ["JVMClassPath", "ClassPath"]:
     if cp_key in pl:
         if isinstance(pl[cp_key], list):
@@ -290,9 +273,6 @@ EOF
         echo "[+] Successfully re-signed ProjectZomboid.app"
     fi
 
-# ==============================================================================
-# Linux Steam Installation
-# ==============================================================================
 else
     echo "[*] Platform: Linux"
 
@@ -325,7 +305,6 @@ else
     INSTALLED_JAR="$PZ_DIR/PZOptimEngine.jar"
     JSON_FILE="$PZ_DIR/ProjectZomboid64.json"
 
-    # Existing Installation Check on Linux
     if [ -f "$INSTALLED_JAR" ]; then
         echo ""
         echo "[!] PZOptimEngine is already installed on Linux."
@@ -359,7 +338,6 @@ else
         esac
     fi
 
-    # Check for ZombieBuddy conflict on Linux
     if [ -f "$PZ_DIR/ZombieBuddy.jar" ] || [ -f "$PZ_DIR/zbNative.so" ] || [ -f "$PZ_DIR/zbNative.dylib" ] || [ -f "$PZ_DIR/zombiebuddy.json" ]; then
         echo ""
         echo "========================================================================"
@@ -371,7 +349,6 @@ else
         echo "[+] ZombieBuddy detected! Coexistence mode enabled." 
     fi
 
-    # Check for Zed Better FPS NG conflict / redundancy
     if [ -d "$HOME/Zomboid/mods/ZBBetterFPSNG" ] || [ -d "$SCRIPT_DIR/../../workshop/content/108600/3793137588" ]; then
         echo ""
         echo "[!] NOTICE: Zed Better FPS NG detected in Workshop/Mods!"
@@ -382,11 +359,9 @@ else
         echo ""
     fi
 
-    # Copy JAR
     cp -f "$PZ_JAR" "$INSTALLED_JAR"
     echo "[+] Installed PZOptimEngine.jar -> $INSTALLED_JAR"
 
-    # Install libpzo_native64.so if present
     for so_c in "$SCRIPT_DIR/libpzo_native64.so" "$SCRIPT_DIR/dist/libpzo_native64.so" "$SCRIPT_DIR/../dist/libpzo_native64.so" "$SCRIPT_DIR/native/libpzo_native64.so"; do
         if [ -f "$so_c" ]; then
             cp -f "$so_c" "$PZ_DIR/libpzo_native64.so"
@@ -403,7 +378,6 @@ else
         echo "[+] Backed up original JSON config -> ${JSON_FILE}.bak"
     fi
 
-    # Safely update JSON while preserving existing classpath and libraries using Python
     python3 - << 'EOF' "$JSON_FILE" "$ALLOC_RAM" "$RAM_MB"
 import sys, json, os
 
@@ -419,10 +393,8 @@ if os.path.exists(json_file):
     except Exception:
         data = {}
 
-# Set optimized main entrypoint
 data["mainClass"] = "com/pzoptimizer/PZOEntrypoint"
 
-# Preserve existing classpath and ensure PZOptimEngine.jar is present
 cp = data.get("classpath", [])
 if not isinstance(cp, list):
     cp = []
@@ -432,7 +404,6 @@ if "." not in cp:
     cp.insert(0, ".")
 data["classpath"] = cp
 
-# Filter and update vmArgs
 existing_args = data.get("vmArgs", [])
 if not isinstance(existing_args, list):
     existing_args = []
@@ -448,7 +419,6 @@ for arg in existing_args:
         not arg.startswith("-XX:G1ReservePercent") and
         not arg.startswith("-XX:+PerfDisableSharedMem")):
         
-        # Automatically sanitize Windows library path if running on Linux
         if arg.startswith("-Djava.library.path="):
             if "win64" in arg:
                 arg = "-Djava.library.path=linux64/:natives/:."

--- a/src/com/pzoptimizer/AssetCachePrewarmer.java
+++ b/src/com/pzoptimizer/AssetCachePrewarmer.java
@@ -5,10 +5,6 @@ import java.io.FileInputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
-/**
- * Non-blocking Background Texture & Asset Cache Pre-Warmer.
- * Reads texture pack headers into OS page cache at boot and immediately releases file handles.
- */
 public class AssetCachePrewarmer {
     public static void startPrewarmingAsync() {
         Thread prewarmer = new Thread(() -> {
@@ -20,7 +16,7 @@ public class AssetCachePrewarmer {
                 if (mediaDir.exists() && mediaDir.isDirectory()) {
                     File[] files = mediaDir.listFiles((dir, name) -> name.endsWith(".pack") || name.endsWith(".png") || name.endsWith(".tiles"));
                     if (files != null) {
-                        ByteBuffer buffer = ByteBuffer.allocate(131072); // 128KB direct sample
+                        ByteBuffer buffer = ByteBuffer.allocate(131072); // 128 KB sample
                         int count = 0;
                         for (File f : files) {
                             if (f.isFile() && f.canRead()) {

--- a/src/com/pzoptimizer/AsyncEntityDistanceCache.java
+++ b/src/com/pzoptimizer/AsyncEntityDistanceCache.java
@@ -1,13 +1,5 @@
 package com.pzoptimizer;
 
-/**
- * PZO Async Entity Distance Matrix & Spatial Cache (Phase 3 SIMD Architecture).
- * Provides high-speed, zero-allocation squared distance math for proximity checks,
- * zombie vision culling, and simulation level bucketing.
- * 
- * Bridges with HordeSpatialCuller for instant AVX2-accelerated queries across 2,000+ entities.
- * 100% deterministic and thread-safe.
- */
 public final class AsyncEntityDistanceCache {
 
     public static final float PROXIMITY_CLOSE_SQ = 100.0f;   // 10 tiles squared
@@ -43,10 +35,7 @@ public final class AsyncEntityDistanceCache {
         return HordeSpatialCuller.getZombieCount();
     }
 
-    /**
-     * Fast distance evaluation without square root.
-     * Returns 0 for close (<10m), 1 for medium (<30m), 2 for far (<60m), 3 for out-of-range (>80m).
-     */
+    /** Returns tiers 0..4 for squared distances <=100, <=900, <=3600, <=6400, and beyond. */
     public static int classifyDistance(float playerX, float playerY, float objX, float objY) {
         float dSq = PZOFastMath.distSq(playerX, playerY, objX, objY);
         if (dSq <= PROXIMITY_CLOSE_SQ) return 0;

--- a/src/com/pzoptimizer/AudioOptimizer.java
+++ b/src/com/pzoptimizer/AudioOptimizer.java
@@ -1,18 +1,12 @@
 package com.pzoptimizer;
 
-/**
- * Project Zomboid Build 42 - Audio Pipeline & Thread Priority Protector.
- * Preserves 100% vanilla and modded sound fidelity with zero voice dropping or clipping.
- */
 public class AudioOptimizer {
 
     public static boolean shouldPlayAudio(String soundName) {
-        // 100% transparent: never drop any gameplay or zombie survival sounds
         return true;
     }
 
     public static boolean shouldProcessSpatialEmitter(float distSq, float volume) {
-        // 100% transparent: allow FMOD native spatial processing to handle attenuation naturally
         return true;
     }
 

--- a/src/com/pzoptimizer/ChunkBufferPool.java
+++ b/src/com/pzoptimizer/ChunkBufferPool.java
@@ -2,10 +2,6 @@ package com.pzoptimizer;
 
 import java.nio.ByteBuffer;
 
-/**
- * Project Zomboid Build 42 - Reusable Thread-Local Chunk Decompression Buffers.
- * Eliminates repeated 128KB-256KB byte array allocations during high-speed vehicle driving.
- */
 public class ChunkBufferPool {
     public static volatile boolean enabled = true;
 

--- a/src/com/pzoptimizer/ChunkCrashShield.java
+++ b/src/com/pzoptimizer/ChunkCrashShield.java
@@ -2,11 +2,6 @@ package com.pzoptimizer;
 
 import java.lang.reflect.Field;
 
-/**
- * Project Zomboid Build 42 - Corrupt Chunk & Savegame Recovery Shield.
- * Prevents game-ending crashes when encountering truncated, corrupted, or
- * invalid map chunk files (map_X_Y.bin) from crashed saves or removed map mods.
- */
 public class ChunkCrashShield {
     private static volatile int recoveredChunks = 0;
 
@@ -19,15 +14,7 @@ public class ChunkCrashShield {
         return recoveredChunks;
     }
 
-    /**
-     * Project Zomboid Build 42 - IsoChunkMap Parity & Coordinate Sanity Shield.
-     * Prevents fatal 'ArrayIndexOutOfBoundsException: Index 271 out of bounds for length 256'
-     * caused by even chunkGridWidth values (e.g. 16 instead of odd 13, 15, 17, 19).
-     * 
-     * In PZ's centered chunk grid (2*R + 1), width must always be odd.
-     * If an even width is detected or swap buffers are undersized, this guard
-     * corrects the grid parity and transparently expands swap buffers.
-     */
+    /** The centered chunk grid requires an odd width (2 * radius + 1) and matching swap-buffer capacity. */
     public static void enforceChunkGridSanity() {
         try {
             PopTemplateGuard.ensurePopulated();
@@ -37,9 +24,9 @@ public class ChunkCrashShield {
 
             if (width > 0) {
                 if (width % 2 != 0) {
-                    return; // Already valid odd grid parity (13x13, 11x11, 9x9) - do not touch!
+                    return;
                 }
-                int safeWidth = width + 1; // Force to safe odd number (e.g. 16 -> 17)
+                int safeWidth = width + 1;
                 widthField.setInt(null, safeWidth);
 
                 try {

--- a/src/com/pzoptimizer/ChunkIngestionPacer.java
+++ b/src/com/pzoptimizer/ChunkIngestionPacer.java
@@ -4,27 +4,11 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-/**
- * PZO Frame-Budgeted Chunk Ingestion Pacer (Next-Gen Chunk Streaming Engine).
- * 
- * In Build 42 with 32 vertical levels (-16 to +16), each chunk contains 2,048 IsoGridSquare instances.
- * In vanilla PZ, when WorldStreamer finishes loading 6-12 chunks from disk, they are all dumped into
- * IsoChunk.loadGridSquare, and IsoChunkMap.processAllLoadGridSquare() drains the ENTIRE queue in a single frame,
- * forcing the main thread to instantiate and stitch 15,000+ squares at once. This produces massive 100-250ms freeze spikes.
- * 
- * ChunkIngestionPacer installs a time-sliced pacing governor onto IsoChunk.loadGridSquare:
- * - Enforces a strict frame budget (default 2.5 ms maximum or max 2 chunks per frame during gameplay).
- * - Leaves subsequent chunks in the thread-safe queue to be smoothly ingested over the next 1-2 frames.
- * - During loading screens and world generation (IngameState.loading == true), budget limits are bypassed
- *   for instantaneous game boot.
- * - Eliminates 100% of chunk integration hitches and locks frame pacing at steady 60/144 FPS.
- */
 public final class ChunkIngestionPacer {
 
     private static volatile boolean active = false;
     private static volatile boolean pacerInstalled = false;
 
-    // Time budget in nanoseconds (3.5 milliseconds = 3,500,000 ns for high-refresh 165Hz)
     public static final long FRAME_BUDGET_NANOS = 3_500_000L;
     public static final int MAX_CHUNKS_PER_FRAME = 3;
     private static volatile int maxCachedChunks = 1000;
@@ -135,18 +119,6 @@ public final class ChunkIngestionPacer {
 
     private static volatile int lastUnloadFrameCount = -1;
 
-    /**
-     * Smoothly paces the teardown of orphaned chunks from IsoChunkMap.SharedChunks.
-     * 
-     * In Build 42, crossing a chunk boundary at 120+ km/h leaves 13 trailing chunks outside the active grid.
-     * In vanilla PZ, IsoChunkMap synchronously removes, tears down squares/navmesh, and queues all 13 chunks in 1 frame (50-80ms freeze).
-     * With our bytecode patch on Up/Down/Left/Right, map shifting takes 0.005ms, leaving trailing chunks in SharedChunks.
-     * 
-     * processPendingUnloads enforces strict mutual exclusion:
-     * - If any chunk was ingested in this frame, unloads are skipped entirely to prevent frame-time stacking.
-     * - On slack frames with 0 ingestion, at most 1 orphaned chunk is unlinked under a 2.5ms ceiling.
-     * - Locks frametimes flat at 60+ FPS while driving.
-     */
     public static boolean isPlayerDriving() {
         return PacedConcurrentQueue.isPlayerDriving();
     }
@@ -154,9 +126,6 @@ public final class ChunkIngestionPacer {
     public static void processPendingUnloads() {
         if (isEngineLoading()) return;
         if (isPlayerDriving()) return; // Do not unload chunks while driving to avoid collision/mesh gaps
-
-        // Budgeted teardowns: Smoothly free at most 1-2 orphaned chunks per frame
-        // under a 1.5ms ceiling, preventing trailing chunk accumulation during vehicle travel.
 
         try {
             if (zombie.iso.IsoWorld.instance == null || zombie.iso.IsoWorld.instance.currentCell == null) return;
@@ -175,7 +144,7 @@ public final class ChunkIngestionPacer {
             }
             lastUnloadFrameCount = currentFrame;
 
-            // Non-blocking tryLock: 0ms lock contention. If bSettingChunk is currently held, skip this tick.
+            // Skip this tick if another thread holds bSettingChunk.
             if (!zombie.iso.IsoChunkMap.bSettingChunk.tryLock()) {
                 return;
             }
@@ -215,7 +184,6 @@ public final class ChunkIngestionPacer {
                                     zombie.iso.ChunkSaveWorker.instance.Add(chunk);
                                 }
                             } catch (Throwable t) {
-                                // Safeguard individual chunk teardowns
                             }
                         }
                         unloadsThisFrame++;
@@ -358,8 +326,7 @@ public final class ChunkIngestionPacer {
                 }
             } catch (Throwable ignored) {}
 
-            // Monotonic frame-freeze watchdog: ONLY reset if > 500ms elapsed (game paused in debugger / external stall)
-            // Prevents the cascading reset bug where an external pause forces subsequent chunks into the same frame.
+            // Reset after a stall longer than 500 ms, not after ordinary frame delays.
             if (now - frameStartTime > 500_000_000L) {
                 frameStartTime = now;
                 chunksThisFrame = 0;
@@ -385,14 +352,9 @@ public final class ChunkIngestionPacer {
 
             long now = System.nanoTime();
 
-            // Precision monotonic frame boundary synchronization:
-            // Checks engine frame counter directly from IsoCamera.frameState.frameCount (0ns overhead)
             checkFrameBoundary(now);
 
-            // Balanced micro-task chunk pacing:
-            // When driving, never artificially throttle ingestion to 1-2 chunks; crossing chunk boundaries
-            // in Build 42 requires 13-26 chunks. We ingest dynamically up to 32 chunks under a 12.0 ms budget ceiling
-            // so vehicles never outrun chunk ingestion or drive into un-ingested missing floor tiles.
+            // Allow a larger ingestion budget while driving so the vehicle does not outrun loaded chunks.
             boolean driving = isPlayerDriving();
             int backlog = approximateSize.get();
             int maxChunks;

--- a/src/com/pzoptimizer/ChunkRetentionRing.java
+++ b/src/com/pzoptimizer/ChunkRetentionRing.java
@@ -2,18 +2,6 @@ package com.pzoptimizer;
 
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * PZO Chunk Retention Ring & Hysteresis Shield (Next-Gen Chunk Streaming Engine).
- * 
- * In vanilla Build 42, crossing back and forth across a chunk boundary causes the engine to
- * immediately unload chunks behind the player, flush them to disk, and re-read them from disk
- * moments later when the player takes a step backward (boundary thrashing).
- * 
- * ChunkRetentionRing maintains a memory-backed LRU retention ring of recently active chunk coordinates:
- * - Retains recent chunks in memory for a 45-second hysteresis window.
- * - Prevents thrashing write-read cycles when looting buildings or fighting near chunk lines.
- * - 100% thread-safe with zero temporary heap allocations.
- */
 public final class ChunkRetentionRing {
 
     private static final int MAX_RETAINED_CHUNKS = 512;
@@ -22,24 +10,17 @@ public final class ChunkRetentionRing {
     private static final ConcurrentHashMap<Long, Long> RETAINED_CHUNKS = new ConcurrentHashMap<>(MAX_RETAINED_CHUNKS);
     private static volatile long lastSweepTime = 0;
 
-    /**
-     * Records access to chunk (wx, wy), updating its retention timestamp.
-     */
     public static void touch(int wx, int wy) {
         long key = FastChunkKey.pack(wx, wy);
         long now = System.currentTimeMillis();
         RETAINED_CHUNKS.put(key, now);
 
-        // Perform periodic sweep every 15 seconds
         if (now - lastSweepTime > 15_000L) {
             lastSweepTime = now;
             sweepExpired(now);
         }
     }
 
-    /**
-     * Checks if chunk (wx, wy) is within the active retention window.
-     */
     public static boolean isRetained(int wx, int wy) {
         long key = FastChunkKey.pack(wx, wy);
         Long ts = RETAINED_CHUNKS.get(key);
@@ -47,9 +28,6 @@ public final class ChunkRetentionRing {
         return (System.currentTimeMillis() - ts) < RETENTION_DURATION_MS;
     }
 
-    /**
-     * Returns total number of retained chunks currently in memory.
-     */
     public static int getRetainedCount() {
         return RETAINED_CHUNKS.size();
     }

--- a/src/com/pzoptimizer/ContainerConfiguratorGuard.java
+++ b/src/com/pzoptimizer/ContainerConfiguratorGuard.java
@@ -8,23 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-/**
- * Project Zomboid Build 42 - Modded Container & ItemConfigurator Dynamic Registration Guard.
- * 
- * In Build 42, custom modded vehicles (KI5, DAMN, etc.) define custom container types
- * (e.g. CAM69Trunk, E150Trunk, CVPI92Trunk, KI5TRCSTrunk).
- * Vanilla ItemConfigurator only pre-registers standard vanilla strings during boot.
- * 
- * When ItemPickInfo.GetPickInfo() queries an unregistered container type, ItemConfigurator.GetIdForString()
- * returns -1, causing the engine to flood console.txt with:
- *   "ItemPickInfo -> cannot get ID for container: Type"
- * synchronously on the main render thread multiple times every single frame.
- * 
- * ContainerConfiguratorGuard wraps ItemConfigurator.STRING_INTEGER_HASH_MAP with an
- * auto-registering map via Unsafe. Any container queried is dynamically assigned a valid ID
- * on-the-fly, completely silencing log spam, eliminating synchronous disk I/O freezes,
- * and ensuring modded vehicle container looting operates correctly.
- */
+/** Registers missing modded container IDs and reinstalls the map after world reloads. */
 public final class ContainerConfiguratorGuard {
 
     private static final AtomicBoolean initialized = new AtomicBoolean(false);
@@ -39,7 +23,6 @@ public final class ContainerConfiguratorGuard {
         obtainUnsafe();
         installGuard();
 
-        // Background daemon to ensure guard persists across world reloads
         Thread guardDaemon = new Thread(ContainerConfiguratorGuard::daemonLoop, "PZO-ContainerGuard");
         guardDaemon.setDaemon(true);
         guardDaemon.setPriority(Thread.MIN_PRIORITY);

--- a/src/com/pzoptimizer/CorpseAudioGovernor.java
+++ b/src/com/pzoptimizer/CorpseAudioGovernor.java
@@ -2,12 +2,6 @@ package com.pzoptimizer;
 
 import java.lang.reflect.Field;
 
-/**
- * PZO Corpse Audio Governor & Spatial Sound Limiter.
- * Dynamically caps dead body audio scan counts in massive slaughter zones
- * to prevent FMOD mixer thread contention while preserving immersive ambient flies.
- * 100% safe, reflection-based, and cross-platform.
- */
 public final class CorpseAudioGovernor {
 
     public static void applyCorpseAudioLimits() {
@@ -16,7 +10,6 @@ public final class CorpseAudioGovernor {
             Field maxCorpseField = fliesClass.getField("maxCorpseCount");
             int currentMax = maxCorpseField.getInt(null);
             
-            // Limit from 25-50 down to a responsive 12 bodies per chunk
             if (currentMax > 12) {
                 maxCorpseField.setInt(null, 12);
                 PZOLogger.success("CorpseAudioGovernor: Paced corpse audio emitters (maxCorpseCount = 12)");

--- a/src/com/pzoptimizer/DirectBufferAllocatorGovernor.java
+++ b/src/com/pzoptimizer/DirectBufferAllocatorGovernor.java
@@ -4,12 +4,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 
-/**
- * PZO DirectBufferAllocator Governor & Zero-Stall Native VRAM Optimizer.
- * Periodically trims and compacts zombie.core.utils.DirectBufferAllocator's tracking list,
- * eliminating the expensive O(N) backward linear scan and array shift stalls during texture allocation.
- * 100% thread-safe, non-invasive, and zero crash risk.
- */
 public final class DirectBufferAllocatorGovernor {
 
     private static volatile boolean running = false;
@@ -38,7 +32,6 @@ public final class DirectBufferAllocatorGovernor {
                             @SuppressWarnings("unchecked")
                             ArrayList<Object> allList = (ArrayList<Object>) allField.get(null);
                             if (allList != null && allList.size() > 64) {
-                                // Fast single-pass in-place compaction
                                 allList.removeIf(item -> {
                                     if (item == null) return true;
                                     try {

--- a/src/com/pzoptimizer/DirectBufferRingPool.java
+++ b/src/com/pzoptimizer/DirectBufferRingPool.java
@@ -4,10 +4,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-/**
- * Zero-Fragmentation Native Direct NIO Buffer Ring Pool.
- * Pre-warms and pools 4KB page-aligned off-heap buffers for chunk decompression and texture streaming.
- */
 public class DirectBufferRingPool {
     private static final int BUFFER_SIZE = 131072; // 128KB direct native buffer
     private static final int POOL_SIZE = 16;
@@ -21,9 +17,6 @@ public class DirectBufferRingPool {
         }
     }
 
-    /**
-     * Acquire a clean, pre-allocated native direct byte buffer.
-     */
     public static ByteBuffer acquire() {
         ByteBuffer buf = pool.poll();
         if (buf == null) {
@@ -34,9 +27,6 @@ public class DirectBufferRingPool {
         return buf;
     }
 
-    /**
-     * Release a buffer back into the ring pool.
-     */
     public static void release(ByteBuffer buf) {
         if (buf != null && buf.isDirect() && buf.capacity() == BUFFER_SIZE) {
             buf.clear();

--- a/src/com/pzoptimizer/DirectMemoryTuner.java
+++ b/src/com/pzoptimizer/DirectMemoryTuner.java
@@ -1,10 +1,5 @@
 package com.pzoptimizer;
 
-/**
- * Direct NIO Off-Heap Memory & Buffer Pool Optimizer.
- * Enforces 512KB page-aligned native buffers to prevent off-heap fragmentation
- * during high-speed vehicle driving and texture streaming.
- */
 public class DirectMemoryTuner {
     public static void initialize() {
         try {

--- a/src/com/pzoptimizer/DriverOptimizer.java
+++ b/src/com/pzoptimizer/DriverOptimizer.java
@@ -1,13 +1,8 @@
 package com.pzoptimizer;
 
-/**
- * GPU Driver Pipeline Multi-Threading Optimizer.
- * Injects safe driver-level multi-threading hints for NVIDIA, AMD, and Linux/Steam Deck Mesa drivers.
- */
 public class DriverOptimizer {
     public static void initialize() {
         try {
-            // LWJGL & OpenGL driver pipeline hints
             System.setProperty("org.lwjgl.opengl.Display.enableHighDPI", "true");
             System.setProperty("org.lwjgl.opengl.Display.noDynamicVSync", "true");
             System.setProperty("org.lwjgl.system.allocator", "system");

--- a/src/com/pzoptimizer/DynamicLightingCuller.java
+++ b/src/com/pzoptimizer/DynamicLightingCuller.java
@@ -4,15 +4,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 
-/**
- * PZO Dynamic Lighting & Frustum Shadow Culler.
- * In Build 42, dynamic light cones, room lights, and vehicle headlights
- * compute multi-pass shadow geometry even when entirely outside the camera's viewport.
- * 
- * This culler performs fast bounding box tests against the active IsoCamera frustum
- * and skips lighting draw calls for out-of-view light sources, saving significant
- * GPU shader cycles and CPU draw overhead in dense towns at night.
- */
 public final class DynamicLightingCuller {
 
     private static volatile boolean active = false;
@@ -67,8 +58,6 @@ public final class DynamicLightingCuller {
             Field offXField = cameraClass.getField("frameOffX");
             Field offYField = cameraClass.getField("frameOffY");
 
-            // Calculate active viewport bounding bounds in tile coordinates
-            // Lights outside camera view bounds have shadow passes culled
         } catch (Throwable ignored) {}
     }
 

--- a/src/com/pzoptimizer/EngineFeaturesTuner.java
+++ b/src/com/pzoptimizer/EngineFeaturesTuner.java
@@ -3,28 +3,20 @@ package com.pzoptimizer;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-/**
- * Project Zomboid Engine Features & Architecture Tuner.
- * Automatically unlocks 100% verified, rock-solid multi-threaded pathfinding, asynchronous lighting,
- * multi-threaded audio, 13x13 chunk streaming, and shared skeletal animation bone caches.
- */
 public class EngineFeaturesTuner {
 
     public static void initializeEngineFeatures() {
         try {
-            // 1. DebugOptions Multi-Threading & Engine Subsystems (Build 42)
             try {
                 Class<?> debugOptionsClass = Class.forName("zombie.debug.DebugOptions");
                 Field instanceField = debugOptionsClass.getField("instance");
                 Object debugOptionsInstance = instanceField.get(null);
 
                 if (debugOptionsInstance != null) {
-                    // A. Native Code Pathfinding & Navigation (100% thread-safe)
                     setOptionValue(debugOptionsInstance, "threadPathfinding", true);
                     setOptionValue(debugOptionsInstance, "pathfindUseNativeCode", true);
                     setOptionValue(debugOptionsInstance, "pathfindSmoothPlayerPath", true);
 
-                    // B. Multi-Threaded Engine Subsystems (Grid Stacks, Lighting)
                     // Keep threadAnimation = false to prevent experimental Kahlua Lua single-threaded VM crashes
                     // Keep threadAmbient = false, threadSound = false, threadWorld = false to prevent FMOD audio race conditions (e.g. DayZ Ambient Sound TimSort crash)
                     setOptionValue(debugOptionsInstance, "threadAnimation", false);
@@ -35,7 +27,6 @@ public class EngineFeaturesTuner {
                     setOptionValue(debugOptionsInstance, "threadGridStacks", true);
                     setOptionValue(debugOptionsInstance, "threadModelSlotInit", true);
 
-                    // C. Model Texture Size Limiter
                     try {
                         Field modelGroupField = debugOptionsClass.getField("model");
                         Object modelGroup = modelGroupField.get(debugOptionsInstance);
@@ -48,7 +39,6 @@ public class EngineFeaturesTuner {
                         }
                     } catch (Throwable ignored) {}
 
-                    // D. FBO Chunk Baking for Corpses & Ground Items (Massive draw-call reduction)
                     try {
                         Field fboGroupField = debugOptionsClass.getField("fboRenderChunk");
                         Object fboGroup = fboGroupField.get(debugOptionsInstance);
@@ -58,7 +48,6 @@ public class EngineFeaturesTuner {
                         }
                     } catch (Throwable ignored) {}
 
-                    // E. Persist thread-safe options to debug-options.ini
                     persistDebugOptionsFile();
 
                     PZOLogger.success("EngineFeaturesTuner: Multi-Threaded Engine Subsystems Armed (GridStacks, Lighting, Pathfinding Native, FBO Baking)");
@@ -67,7 +56,6 @@ public class EngineFeaturesTuner {
                 PZOLogger.info("EngineFeaturesTuner: B42 DebugOptions hook skipped: " + e.getMessage());
             }
 
-            // 2. PerformanceSettings Core Defaults
             try {
                 Class<?> perfClass = Class.forName("zombie.core.PerformanceSettings");
                 
@@ -88,7 +76,7 @@ public class EngineFeaturesTuner {
 
                 try {
                     Field lightFpsField = perfClass.getField("lightingFps");
-                    lightFpsField.setInt(null, 15); // Vanilla 15 FPS lighting updates (halves lighting CPU workload)
+                    lightFpsField.setInt(null, 15);
                 } catch (Throwable ignored) {}
 
                 try {
@@ -98,7 +86,7 @@ public class EngineFeaturesTuner {
 
                 try {
                     Field blendField = perfClass.getField("numberZombiesBlended");
-                    blendField.setInt(null, 16); // High-fidelity skeletal blending for 16 closest zombies
+                    blendField.setInt(null, 16);
                 } catch (Throwable ignored) {}
 
                 // Decoupled UI FBO rendering is left to display initialization to avoid premature TextureFBO probing.
@@ -107,19 +95,16 @@ public class EngineFeaturesTuner {
                 PZOLogger.success("EngineFeaturesTuner: Core Engine PerformanceSettings Optimized (15 FPS Lighting | Skeletal Falloff)");
             } catch (Throwable ignored) {}
 
-            // 3. Enforce IsoChunkMap Grid Parity (Prevent IndexOutOfBoundsException 271 / even chunkGridWidth)
             try {
                 ChunkCrashShield.enforceChunkGridSanity();
             } catch (Throwable ignored) {}
 
-            // 3. Silence Non-Fatal DebugType Warning Spam during Chunk Loading (SpriteConfig, Entities, Objects)
             try {
                 Class<?> debugTypeClass = Class.forName("zombie.debug.DebugType");
                 Class<?> logSeverityClass = Class.forName("zombie.debug.LogSeverity");
                 @SuppressWarnings("rawtypes")
                 Object errorSeverity = Enum.valueOf((Class<Enum>) logSeverityClass.asSubclass(Enum.class), "Error");
 
-                // Set General, Entity, Sprite, Objects, Mod debug types to Error severity
                 String[] typesToSilence = new String[]{"General", "Entity", "Sprite", "Objects", "Mod", "ItemPicker"};
                 for (String typeName : typesToSilence) {
                     try {

--- a/src/com/pzoptimizer/EngineFramePacer.java
+++ b/src/com/pzoptimizer/EngineFramePacer.java
@@ -2,12 +2,6 @@ package com.pzoptimizer;
 
 import java.util.concurrent.locks.LockSupport;
 
-/**
- * PZO Nanosecond-Precise Engine Frame Pacer & Jitter Eraser.
- * Uses hybrid OS timer sleep and CPU nanosecond spin-yielding to guarantee
- * perfectly flat frame times (e.g. exactly 16.666ms at 60 FPS, 6.944ms at 144 FPS).
- * 100% safe across Windows, macOS, and Linux.
- */
 public final class EngineFramePacer {
 
     private static volatile boolean enabled = false;
@@ -27,7 +21,6 @@ public final class EngineFramePacer {
     }
 
     public static void paceFrame(long frameStartNanos) {
-        // Record frame time in telemetry diagnostic probe
         FrameDropDiagnosticEngine.onFrameTick();
 
         if (!enabled) return;
@@ -35,7 +28,7 @@ public final class EngineFramePacer {
         long targetEnd = frameStartNanos + targetFrameTimeNanos;
         long remainingNanos = targetEnd - System.nanoTime();
 
-        // 1. Coarse sleep for the bulk of the wait (leaving 1ms buffer)
+        // Leave 1 ms for the finer waits below.
         if (remainingNanos > 1_500_000L) {
             long sleepMillis = (remainingNanos - 1_000_000L) / 1_000_000L;
             try {
@@ -43,13 +36,11 @@ public final class EngineFramePacer {
             } catch (InterruptedException ignored) {}
         }
 
-        // 2. Fine-grained microsecond park
         remainingNanos = targetEnd - System.nanoTime();
         if (remainingNanos > 100_000L) {
             LockSupport.parkNanos(remainingNanos - 50_000L);
         }
 
-        // 3. Nanosecond spin-yield for exact deadline
         while (System.nanoTime() < targetEnd) {
             Thread.onSpinWait();
         }

--- a/src/com/pzoptimizer/EngineGLStateGovernor.java
+++ b/src/com/pzoptimizer/EngineGLStateGovernor.java
@@ -1,11 +1,5 @@
 package com.pzoptimizer;
 
-/**
- * PZO Deep Engine-Level OpenGL State Governor.
- * Shadows active OpenGL texture bindings, blend modes, alpha functions,
- * and shader programs in CPU L1 cache, eliminating thousands of redundant JNI driver calls per frame.
- * 100% thread-safe, deterministic, and cross-platform.
- */
 public final class EngineGLStateGovernor {
 
     private static volatile int activeTextureId = -1;
@@ -21,7 +15,7 @@ public final class EngineGLStateGovernor {
 
     public static boolean shouldBindTexture(int textureId) {
         if (textureId == activeTextureId) {
-            return false; // Skip redundant JNI bind
+            return false;
         }
         activeTextureId = textureId;
         return true;
@@ -29,7 +23,7 @@ public final class EngineGLStateGovernor {
 
     public static boolean shouldSetProgram(int programId) {
         if (programId == activeProgramId) {
-            return false; // Skip redundant shader use
+            return false;
         }
         activeProgramId = programId;
         return true;

--- a/src/com/pzoptimizer/EngineThreadGovernor.java
+++ b/src/com/pzoptimizer/EngineThreadGovernor.java
@@ -4,27 +4,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-/**
- * Project Zomboid Build 42 - Dedicated High-Performance Thread and Scheduler Governor.
- * 
- * Intercepts the engine's core execution pipelines:
- * 1. RenderThread (via RenderThread.queueInvokeOnRenderContext):
- *    - Elevates priority to THREAD_PRIORITY_HIGHEST (+2)
- *    - Binds affinity directly to physical Performance Cores (P-Cores)
- *    - Registers thread with Windows Multimedia Class Scheduler Service (MMCSS "Games")
- *    - Eliminates micro-stutter and frame-time variance during vehicle travel in dense towns
- * 
- * 2. MainThread (via MainThread.queueInvokeOnMainThread):
- *    - Elevates priority to THREAD_PRIORITY_ABOVE_NORMAL (+1)
- *    - Binds affinity to physical Performance Cores (P-Cores)
- *    - Registers with Windows MMCSS "Games"
- * 
- * 3. Working Set and Physical RAM Lock:
- *    - Invokes SetProcessWorkingSetSizeEx to prevent Windows memory trimming
- * 
- * 4. Asynchronous Subsystem Worker Affinity:
- *    - Ensures LightingThread, WorldStreamer, and PathfindNativeThread run with rock-solid scheduling
- */
 public class EngineThreadGovernor {
 
     private static final AtomicBoolean initialized = new AtomicBoolean(false);
@@ -37,7 +16,6 @@ public class EngineThreadGovernor {
         }
 
         try {
-            // 1. Process-wide Working Set Lock and High Priority
             if (PZONative.isLoaded()) {
                 PZONative.lockProcessWorkingSet();
                 PZONative.setProcessPriority(2); // HIGH_PRIORITY_CLASS
@@ -49,7 +27,6 @@ public class EngineThreadGovernor {
             PZOLogger.warn("[EngineThreadGovernor] Process lock notice: " + t.getMessage());
         }
 
-        // 2. Launch asynchronous hooker daemon to catch RenderThread and MainThread upon engine boot
         Thread governorDaemon = new Thread(EngineThreadGovernor::governorLoop, "PZO-ThreadGovernor");
         governorDaemon.setDaemon(true);
         governorDaemon.setPriority(Thread.MIN_PRIORITY);
@@ -62,20 +39,16 @@ public class EngineThreadGovernor {
         int backoffMs = 100;
         while (true) {
             try {
-                // Try hooking RenderThread if not yet optimized
                 if (!renderThreadOptimized) {
                     tryHookRenderThread();
                 }
 
-                // Try hooking MainThread if not yet fully optimized and paced
                 if (!mainThreadOptimized || !mainThreadPacerHooked) {
                     tryHookMainThread();
                 }
 
-                // Maintain background workers (LightingThread, PathfindNativeThread, WorldStreamer)
                 maintainWorkerThreads();
 
-                // Once primary threads are optimized and paced, relax polling to 5000ms
                 if (renderThreadOptimized && mainThreadOptimized && mainThreadPacerHooked) {
                     backoffMs = 5000;
                 } else {
@@ -155,7 +128,7 @@ public class EngineThreadGovernor {
                 });
             }
 
-            // Hook MainThread.mainThreadLoop with Zero-Lock Diagnostic Probe (No Sleeping, Zero Lock Contention)
+            // Sample mainThreadLoop without sleeping on the main thread.
             if (!mainThreadPacerHooked) {
                 try {
                     Field loopField = mainThreadClass.getDeclaredField("mainThreadLoop");
@@ -200,12 +173,8 @@ public class EngineThreadGovernor {
         }
     }
 
-    /**
-     * Maintains optimal scheduling for engine worker subsystems (Lighting, Pathfinding).
-     */
     private static void maintainWorkerThreads() {
         try {
-            // LightingThread
             try {
                 Class<?> ltClass = Class.forName("zombie.iso.LightingThread");
                 Field instField = ltClass.getField("instance");
@@ -221,7 +190,6 @@ public class EngineThreadGovernor {
                 }
             } catch (Throwable ignored) {}
 
-            // PathfindNativeThread
             try {
                 Class<?> pfClass = Class.forName("zombie.pathfind.nativeCode.PathfindNativeThread");
                 Field instField = pfClass.getField("instance");

--- a/src/com/pzoptimizer/EnhancedRenderTelemetry.java
+++ b/src/com/pzoptimizer/EnhancedRenderTelemetry.java
@@ -4,19 +4,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.util.Locale;
 
-/**
- * PZO Enhanced Rendering Telemetry & Performance Gain Monitor.
- * 
- * Tracks real-time metrics and estimated hardware resource savings across:
- * - Phase 3 SIMD AVX2 Batch Horde Spatial Culler (HordeSpatialCuller)
- * - 3D Dynamic Skeletal Bone Skinning Governor (HordeAnimationLODGovernor & ModelSkinningGovernor)
- * - 2D Screen-space Draw Call Culling (RenderFrustumCuller)
- * - 32-Level Subterranean Level Occlusion (ZOcclusionCuller)
- * - OpenGL JNI Driver State Filter (GLStateOptimizer)
- * 
- * Only active in Unstable / Beta channel builds.
- * Writes pzo_render_telemetry.json and feeds into live HUD / clipboard diagnostics.
- */
 public final class EnhancedRenderTelemetry {
 
     public static class MetricsSnapshot {
@@ -59,16 +46,11 @@ public final class EnhancedRenderTelemetry {
         snap.parallelSimulatedEntities = com.pzoptimizer.multicore.PZOMultiCoreEngine.getParallelSimulatedEntities();
         snap.multiCoreWorkers = com.pzoptimizer.multicore.PZOMultiCoreEngine.getWorkerCount();
 
-        // Hardware cost weightings:
-        // ~0.0015 ms CPU time saved per culled draw call + state check
-        // ~0.0035 ms GPU raster/vertex time saved per subterranean tile
-        // ~0.0006 ms CPU SIMD time saved per 4x4 bone matrix multiplication
-        // ~0.0010 ms JNI driver switch time saved per redundant GL call
-        // ~0.0040 ms CPU time saved per throttled distant zombie AI / pathfind tick
+        // Assumed per-operation costs in milliseconds, not measured timings.
         snap.estimatedCpuMsSaved = (snap.drawsCulled * 0.0015) + (snap.boneTransformsSaved * 0.0006) + (snap.glCallsFiltered * 0.0010) + (snap.throttledTownZombies * 0.0040);
         snap.estimatedGpuMsSaved = (snap.drawsCulled * 0.0012) + (snap.subterraneanTilesCulled * 0.0035);
 
-        // Baseline frame budget 16.6ms (60 FPS); compute estimated efficiency dividend
+        // Compare the estimate with a fixed 16.6 ms frame budget.
         double frameSavings = Math.min(8.0, (snap.estimatedCpuMsSaved + snap.estimatedGpuMsSaved) / 1000.0);
         snap.estimatedFpsGainPercent = Math.min(75.0, (frameSavings / 16.6) * 100.0);
 

--- a/src/com/pzoptimizer/FMODOcclusionGovernor.java
+++ b/src/com/pzoptimizer/FMODOcclusionGovernor.java
@@ -3,15 +3,6 @@ package com.pzoptimizer;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-/**
- * PZO FMOD Occlusion Governor & Audio Suppression Eliminator.
- * Resolves the Build 42 Unstable acoustic raycasting bug where open/transitioning
- * doors, nearby containers, and player interaction sounds are erroneously occluded
- * to 1.0 (100% muffled/muted).
- * 
- * Clamps audio occlusion to 0.0 for immediate player proximity (<= 3.5 tiles)
- * and player-initiated emitters, guaranteeing crystal clear interaction audio.
- */
 public final class FMODOcclusionGovernor {
 
     private static volatile boolean active = false;
@@ -58,11 +49,9 @@ public final class FMODOcclusionGovernor {
             float pY = ((Number) getYMethod.invoke(primaryPlayer)).floatValue();
             float pZ = ((Number) getZMethod.invoke(primaryPlayer)).floatValue();
 
-            // Check if player is currently interacting or moving through doors
             Field emitterField = primaryPlayer.getClass().getField("emitter");
             Object emitter = emitterField.get(primaryPlayer);
             if (emitter != null) {
-                // Ensure player emitter has zero obstruction/occlusion
             }
         } catch (Throwable ignored) {}
     }

--- a/src/com/pzoptimizer/FastBitwiseChunkIndexer.java
+++ b/src/com/pzoptimizer/FastBitwiseChunkIndexer.java
@@ -1,11 +1,5 @@
 package com.pzoptimizer;
 
-/**
- * PZO 64-Bit Register Spatial Chunk & Meta-Grid Indexer.
- * Operates directly on 64-bit CPU machine registers in 1 instruction,
- * eliminating integer overflow bugs and HashMap coordinate hashing overhead.
- * 100% deterministic and cross-platform.
- */
 public final class FastBitwiseChunkIndexer {
 
     public static void initialize() {
@@ -28,10 +22,7 @@ public final class FastBitwiseChunkIndexer {
         return ((long) (z & 0xFF) << 48) | ((long) (x & 0xFFFFFF) << 24) | (y & 0xFFFFFF);
     }
 
-    /**
-     * Interleaves bits of two 16-bit integers to produce a 32-bit Morton code (Z-order curve index).
-     * Maximizes CPU cache locality for adjacent 2D tile spatial searches.
-     */
+    /** Interleaves two 16-bit coordinates into a 32-bit Morton code. */
     public static int mortonEncode2D(int x, int y) {
         return (spreadBits(x & 0xFFFF)) | (spreadBits(y & 0xFFFF) << 1);
     }

--- a/src/com/pzoptimizer/FastChunkKey.java
+++ b/src/com/pzoptimizer/FastChunkKey.java
@@ -1,29 +1,15 @@
 package com.pzoptimizer;
 
-/**
- * High-Performance Primitive Bitwise Chunk Hash Keyer.
- * Replaces string concatenations ("map_" + wx + "_" + wy) with 64-bit primitive packed integers.
- * Eliminates 100% of temporary heap allocations during vehicle driving and chunk streaming.
- */
 public final class FastChunkKey {
 
-    /**
-     * Packs 2D world chunk coordinates (wx, wy) into a single 64-bit primitive long.
-     */
     public static long pack(int wx, int wy) {
         return (((long) wx) << 32) | (wy & 0xFFFFFFFFL);
     }
 
-    /**
-     * Extracts world X coordinate from packed key.
-     */
     public static int getX(long key) {
         return (int) (key >> 32);
     }
 
-    /**
-     * Extracts world Y coordinate from packed key.
-     */
     public static int getY(long key) {
         return (int) key;
     }

--- a/src/com/pzoptimizer/FastColorTable.java
+++ b/src/com/pzoptimizer/FastColorTable.java
@@ -1,9 +1,5 @@
 package com.pzoptimizer;
 
-/**
- * L1 Pre-Computed RGBA Integer-to-Float Fast Lookup Table.
- * Replaces expensive floating-point divisions (b / 255.0f) with instant O(1) array lookups.
- */
 public final class FastColorTable {
     private static final float[] BYTE_TO_FLOAT = new float[256];
 
@@ -13,9 +9,6 @@ public final class FastColorTable {
         }
     }
 
-    /**
-     * Instantly converts an 8-bit unsigned color channel (0-255) to a 0.0f-1.0f float with zero division latency.
-     */
     public static float getFloat(int byteVal) {
         if (byteVal < 0) return 0.0f;
         if (byteVal > 255) return 1.0f;

--- a/src/com/pzoptimizer/FastJ2SEPlatform.java
+++ b/src/com/pzoptimizer/FastJ2SEPlatform.java
@@ -4,11 +4,6 @@ import se.krka.kahlua.j2se.J2SEPlatform;
 import se.krka.kahlua.j2se.KahluaTableImpl;
 import se.krka.kahlua.vm.KahluaTable;
 
-/**
- * Project Zomboid Build 42 - High-Speed J2SEPlatform Provider.
- * Overrides newTable() to construct KahluaTableImpl instances backed by FastLuaMap,
- * accelerating Lua list and array operations across the entire game engine.
- */
 public class FastJ2SEPlatform extends J2SEPlatform {
 
     private static final FastJ2SEPlatform INSTANCE = new FastJ2SEPlatform();

--- a/src/com/pzoptimizer/FastLuaMap.java
+++ b/src/com/pzoptimizer/FastLuaMap.java
@@ -7,15 +7,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-/**
- * Project Zomboid Build 42 - High-Performance Hybrid Map for KahluaTableImpl.
- * 
- * Stores contiguous 1-based integer keys (1..N) in a flat primitive Object[] array,
- * bypassing hash table bucket overhead, Node allocations, and Double boxing lookups.
- * Seamlessly falls back to LinkedHashMap for string, negative, or sparse non-integer keys.
- * 
- * Guarantees 100% binary, runtime, and save-file compatibility with KahluaTableImpl.
- */
+/** Stores contiguous positive integer keys in an array; other keys use LinkedHashMap. */
 public class FastLuaMap extends AbstractMap<Object, Object> {
 
     private Object[] arrayPart = new Object[16];

--- a/src/com/pzoptimizer/FastMath.java
+++ b/src/com/pzoptimizer/FastMath.java
@@ -1,9 +1,5 @@
 package com.pzoptimizer;
 
-/**
- * Project Zomboid Build 42 - Zero-Allocation Fast Trigonometry & Distance Engine.
- * Precomputes sin/cos lookup tables and 65x65 tile grid distance squared matrices.
- */
 public class FastMath {
     private static final int SIN_BITS = 16;
     private static final int SIN_MASK = (1 << SIN_BITS) - 1;
@@ -51,9 +47,6 @@ public class FastMath {
         return sq * fastInvSqrt(sq);
     }
 
-    /**
-     * Instant L1-cache integer distance squared lookup for tile grids.
-     */
     public static int tileDistSq(int dx, int dy) {
         if (dx >= -OFFSET_RANGE && dx <= OFFSET_RANGE && dy >= -OFFSET_RANGE && dy <= OFFSET_RANGE) {
             return TILE_DIST_SQ[dx + OFFSET_RANGE][dy + OFFSET_RANGE];

--- a/src/com/pzoptimizer/FastPathCache.java
+++ b/src/com/pzoptimizer/FastPathCache.java
@@ -1,10 +1,5 @@
 package com.pzoptimizer;
 
-/**
- * Project Zomboid Build 42 - High-Speed L1 Path Normalization & Interning Cache.
- * Eliminates millions of temporary String and char[] allocations during texture,
- * model, and sound asset loading.
- */
 public class FastPathCache {
     private static final int CACHE_SIZE = 4096;
     private static final int MASK = CACHE_SIZE - 1;
@@ -21,7 +16,6 @@ public class FastPathCache {
             return VAL_CACHE[hash];
         }
 
-        // Fast normalization without regex or unnecessary string copies
         String normalized = path.indexOf('\\') != -1 ? path.replace('\\', '/') : path;
         normalized = ResourceInterner.intern(normalized);
 

--- a/src/com/pzoptimizer/FileSystemWhitelistShield.java
+++ b/src/com/pzoptimizer/FileSystemWhitelistShield.java
@@ -14,19 +14,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import sun.misc.Unsafe;
 
-/**
- * Project Zomboid Build 42 - FileSystem Whitelist & Secondary-Drive Protection Shield.
- * 
- * In Build 42, ZomboidFileSystem.validatePrefix(path) enforces an internal whitelist
- * of allowed base directories (allowedPrefixes). When Steam Workshop mods are installed
- * on a secondary drive (e.g. K:\SteamLibrary, D:\SteamLibrary), the vanilla engine can
- * fail to register these paths in time, or wipe them during ResetMods(), causing
- * validatePrefix to throw IllegalArgumentException and failing animation/model loading.
- * 
- * This shield intercepts allowedPrefixes via a permanent wrapped Supplier and runs
- * an active background watchdog to guarantee that all mounted drives and workshop
- * libraries are 100% permanently whitelisted.
- */
+/** Wraps allowedPrefixes so ResetMods() retains discovered Steam library roots. */
 public final class FileSystemWhitelistShield {
 
     private static volatile boolean initialized = false;
@@ -51,7 +39,6 @@ public final class FileSystemWhitelistShield {
         obtainUnsafe();
         collectAllSearchRoots();
 
-        // Continuous lifecycle daemon: maintains whitelist throughout game boot, main menu, and save loading
         Thread daemon = new Thread(() -> {
             while (true) {
                 try {
@@ -67,7 +54,6 @@ public final class FileSystemWhitelistShield {
     }
 
     private static void collectAllSearchRoots() {
-        // 1. All mounted drive roots (C:\, D:\, K:\, etc.)
         try {
             File[] roots = File.listRoots();
             if (roots != null) {
@@ -94,7 +80,6 @@ public final class FileSystemWhitelistShield {
                             }
                         }
 
-                        // Parse libraryfolders.vdf
                         File vdf1 = new File(root, "Program Files (x86)/Steam/steamapps/libraryfolders.vdf".replace('/', File.separatorChar));
                         if (!vdf1.exists()) {
                             vdf1 = new File(root, "Steam/steamapps/libraryfolders.vdf".replace('/', File.separatorChar));
@@ -107,7 +92,6 @@ public final class FileSystemWhitelistShield {
             }
         } catch (Throwable ignored) {}
 
-        // 2. User Zomboid directory
         try {
             String userHome = System.getProperty("user.home");
             File zomboidDir = new File(userHome, "Zomboid");
@@ -116,7 +100,6 @@ public final class FileSystemWhitelistShield {
             }
         } catch (Throwable ignored) {}
 
-        // 3. Current working directory / execution directory roots
         try {
             File cwd = new File(".").getAbsoluteFile();
             addRootPath(cwd);
@@ -182,7 +165,7 @@ public final class FileSystemWhitelistShield {
                 return false;
             }
 
-            // 1. Hook the ResettableLazyValue supplier permanently so resets NEVER drop discovered roots
+            // Reapply discovered roots when ResettableLazyValue recreates its value.
             Field allowedField = fsClass.getDeclaredField("allowedPrefixes");
             allowedField.setAccessible(true);
             Object lazy = allowedField.get(fsInstance);
@@ -232,9 +215,7 @@ public final class FileSystemWhitelistShield {
         } catch (Throwable ignored) {}
     }
 
-    /**
-     * Unbreakable supplier wrapper: always ensures discovered secondary drive roots are included.
-     */
+    /** Adds discovered roots to the wrapped supplier result. */
     private static final class PZOShieldSupplier implements Supplier<List<Path>> {
         private final Supplier<List<Path>> delegate;
         private final Set<String> roots;

--- a/src/com/pzoptimizer/FrameDropDiagnosticEngine.java
+++ b/src/com/pzoptimizer/FrameDropDiagnosticEngine.java
@@ -13,12 +13,6 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-/**
- * PZO Real-Time Frame-Time Profiler & Stutter Diagnostic Engine.
- * Measures nanosecond frame times, detects frame drops / micro-stutters,
- * and snapshots multi-subsystem engine metrics to identify the exact root cause.
- * 100% thread-safe, low-overhead, and cross-platform.
- */
 public final class FrameDropDiagnosticEngine {
 
     private static volatile boolean running = false;
@@ -42,10 +36,8 @@ public final class FrameDropDiagnosticEngine {
         if (running) return;
         running = true;
 
-        // Initialize baseline GC stats
         updateGcStats();
 
-        // Background file logger daemon
         Thread loggerThread = new Thread(() -> {
             PZOLogger.success("FrameDropDiagnosticEngine: Active (Real-Time Stutter Diagnostics & Root Cause Telemetry)");
 
@@ -65,9 +57,6 @@ public final class FrameDropDiagnosticEngine {
         loggerThread.start();
     }
 
-    /**
-     * Called on each rendered frame to compute frame time and detect stutter anomalies.
-     */
     public static void onFrameTick() {
         long now = System.nanoTime();
         long deltaNanos = now - lastFrameTimeNanos;
@@ -80,18 +69,15 @@ public final class FrameDropDiagnosticEngine {
 
         double frameTimeMs = deltaNanos / 1_000_000.0;
 
-        // Store rolling history
         frameTimeHistory[historyIndex] = frameTimeMs;
         historyIndex = (historyIndex + 1) % frameTimeHistory.length;
         totalFramesSampled++;
 
-        // Stutter detection threshold: >28ms (<35 FPS) or >1.8x average frame time
         double avgFrameTime = getAverageFrameTime();
         if (frameTimeMs > 28.0 && frameTimeMs > avgFrameTime * 1.65) {
             diagnoseFrameDrop(frameTimeMs, avgFrameTime);
         }
 
-        // Periodically update live telemetry file (every 60 frames)
         if (totalFramesSampled % 60 == 0) {
             updateLiveTelemetry(frameTimeMs, avgFrameTime);
         }
@@ -101,14 +87,13 @@ public final class FrameDropDiagnosticEngine {
         stutterCount++;
         lastStutterMs = frameTimeMs;
 
-        // 1. Check GC Pause Delta
         long gcCountBefore = lastGcCount;
         long gcTimeBefore = lastGcTimeMs;
         updateGcStats();
         long gcDeltaCount = lastGcCount - gcCountBefore;
         long gcDeltaTimeMs = lastGcTimeMs - gcTimeBefore;
 
-        // 2. Query Game State via reflection (100% crash-proof)
+        // Game classes may not be available during startup.
         boolean isDriving = false;
         float vehicleSpeed = 0.0f;
         float playerX = 0.0f, playerY = 0.0f;
@@ -141,7 +126,6 @@ public final class FrameDropDiagnosticEngine {
                 }
             }
 
-            // Query Cell entities
             Class<?> worldClass = Class.forName("zombie.iso.IsoWorld");
             Field instField = worldClass.getField("instance");
             Object worldInst = instField.get(null);
@@ -155,7 +139,6 @@ public final class FrameDropDiagnosticEngine {
                 }
             }
 
-            // Query WorldStreamer queue
             Class<?> wsClass = Class.forName("zombie.iso.WorldStreamer");
             Object wsInst = wsClass.getField("instance").get(null);
             if (wsInst != null) {
@@ -165,7 +148,6 @@ public final class FrameDropDiagnosticEngine {
                 if (q != null) wsQueueSize = q.size();
             }
 
-            // Query ChunkSaveWorker queue
             Class<?> cswClass = Class.forName("zombie.iso.ChunkSaveWorker");
             Object cswInst = cswClass.getField("instance").get(null);
             if (cswInst != null) {
@@ -174,7 +156,6 @@ public final class FrameDropDiagnosticEngine {
                 if (sq != null) saveQueueSize = sq.size();
             }
 
-            // Query IsoChunk.loadGridSquare ingestion queue
             Class<?> chunkClass = Class.forName("zombie.iso.IsoChunk");
             Field lgsField = chunkClass.getField("loadGridSquare");
             Object lgsObj = lgsField.get(null);
@@ -188,7 +169,6 @@ public final class FrameDropDiagnosticEngine {
         lastDiagnosedChunkX = chunkX;
         lastDiagnosedChunkY = chunkY;
 
-        // 3. Classify Root Cause
         String cause;
         if (gcDeltaTimeMs > 5) {
             cause = "GC_STW_PAUSE (" + gcDeltaTimeMs + "ms)";
@@ -212,7 +192,6 @@ public final class FrameDropDiagnosticEngine {
 
         lastStutterCause = cause;
 
-        // 4. Log Stutter Report
         String timestamp = DATE_FORMAT.format(new Date());
         String logEntry = String.format(
             "[%s] STUTTER: %.1f ms (Avg: %.1f ms | FPS: %.0f) -> ROOT CAUSE: [%s] | Pos: (%.0f, %.0f | Ch: %d,%d) | Driving: %b | Zombies: %d | WSQueue: %d | SaveQueue: %d | GC: %dms",
@@ -220,7 +199,6 @@ public final class FrameDropDiagnosticEngine {
         );
 
         pendingDiagnosticLogs.offer(logEntry);
-       // PZOLogger.warn(logEntry);
     }
 
     private static void updateGcStats() {
@@ -231,7 +209,7 @@ public final class FrameDropDiagnosticEngine {
             for (GarbageCollectorMXBean gc : gcs) {
                 String name = gc.getName();
                 if (name != null && name.contains("Cycles")) {
-                    // Ignore concurrent background cycles under ZGC (sub-millisecond STW pause)
+                    // Exclude concurrent background cycles from pause accounting.
                     continue;
                 }
                 long c = gc.getCollectionCount();
@@ -285,7 +263,6 @@ public final class FrameDropDiagnosticEngine {
         if (pendingDiagnosticLogs.isEmpty()) return;
 
         List<File> targetDirs = new ArrayList<>();
-        // Check discovered Zomboid directories
         String userHome = System.getProperty("user.home");
         if (userHome != null) {
             targetDirs.add(new File(userHome, "Zomboid" + File.separator + "Logs"));

--- a/src/com/pzoptimizer/GLStateOptimizer.java
+++ b/src/com/pzoptimizer/GLStateOptimizer.java
@@ -2,10 +2,6 @@ package com.pzoptimizer;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-/**
- * Project Zomboid Build 42 - Advanced OpenGL & Shader State Optimizer.
- * Eliminates thousands of redundant GPU uniform, matrix, texture, alpha, and depth calls per frame.
- */
 public class GLStateOptimizer {
     public static volatile boolean enabled = true;
 
@@ -13,27 +9,22 @@ public class GLStateOptimizer {
         enabled = value;
     }
 
-    // Live Optimization Telemetry Counters
     public static final AtomicLong glCallsFiltered = new AtomicLong(0);
     public static final AtomicLong matricesSkipped = new AtomicLong(0);
     public static final AtomicLong uniformsSkipped = new AtomicLong(0);
 
-    // 1. Texture & Color Caches
     private static int currentTexture = -1;
     private static float currentR = -1f, currentG = -1f, currentB = -1f, currentA = -1f;
     private static int currentSrcBlend = -1, currentDstBlend = -1;
 
-    // 2. Alpha & Depth Caching (IndieGL hot loops)
     private static int lastAlphaFunc = -1;
     private static float lastAlphaRef = -1.0f;
     private static int lastDepthFunc = -1;
     private static int lastDepthMask = -1; // 0=false, 1=true
 
-    // 3. Chunk Depth Shader Uniform Caching (DefaultShader)
     private static int chunkDepthLoc = -2;
     private static float cachedChunkDepth = Float.NaN;
 
-    // 4. General Shader Uniform State Caching (256-entry uniform table)
     private static final int UNIFORM_TABLE_SIZE = 256;
     private static final float[] cachedUniform1f = new float[UNIFORM_TABLE_SIZE];
     private static final int[] cachedUniform1i = new int[UNIFORM_TABLE_SIZE];
@@ -42,7 +33,6 @@ public class GLStateOptimizer {
     private static final boolean[] uniform1iValid = new boolean[UNIFORM_TABLE_SIZE];
     private static final boolean[] uniform4fValid = new boolean[UNIFORM_TABLE_SIZE];
 
-    // 5. Skinned 3D Model Matrix Uniform Cache (1024-entry shader table)
     public static class ShaderMatrixState {
         public int uniformLoc = -2;
         public float[] lastMatrix = new float[16];
@@ -178,14 +168,13 @@ public class GLStateOptimizer {
             return true;
         }
 
-        // Fast float-by-float unrolled matrix comparison (Zero memory allocation)
         float[] last = state.lastMatrix;
         if (last[0] == newMatrix[0] && last[1] == newMatrix[1] && last[2] == newMatrix[2] && last[3] == newMatrix[3] &&
             last[4] == newMatrix[4] && last[5] == newMatrix[5] && last[6] == newMatrix[6] && last[7] == newMatrix[7] &&
             last[8] == newMatrix[8] && last[9] == newMatrix[9] && last[10] == newMatrix[10] && last[11] == newMatrix[11] &&
             last[12] == newMatrix[12] && last[13] == newMatrix[13] && last[14] == newMatrix[14] && last[15] == newMatrix[15]) {
             matricesSkipped.incrementAndGet();
-            return false; // Matrix matches cached state, skip redundant GPU upload
+            return false;
         }
 
         System.arraycopy(newMatrix, 0, state.lastMatrix, 0, 16);

--- a/src/com/pzoptimizer/GenerationalHeapCleaner.java
+++ b/src/com/pzoptimizer/GenerationalHeapCleaner.java
@@ -2,12 +2,6 @@ package com.pzoptimizer;
 
 import java.lang.reflect.Method;
 
-/**
- * PZO Smart Generational Heap Cleaner & Zero-Pause GC Governor.
- * Monitors gameplay state and triggers concurrent memory compaction during safe idle windows
- * (standing still, looting, reading, paused) so GC cleanups NEVER interrupt driving or combat.
- * 100% thread-safe, low-overhead, and cross-platform on Windows, macOS, and Linux.
- */
 public final class GenerationalHeapCleaner {
 
     private static volatile boolean running = false;
@@ -15,24 +9,20 @@ public final class GenerationalHeapCleaner {
     private static final long MIN_GC_INTERVAL_MS = 60_000; // Minimum 60s between idle sweeps
 
     public static void startGovernor() {
-        // Maintained as passive non-blocking monitor. Explicit System.gc() is strictly disabled
-        // to ensure HotSpot G1GC manages memory concurrently with zero Stop-The-World pauses.
+        // Leave garbage collection to the JVM; do not call System.gc() here.
         PZOLogger.success("GenerationalHeapCleaner: Zero-Pause Memory Governor initialized (Passive Concurrent Mode)");
     }
 
     private static boolean checkSafeMoment() {
         try {
-            // Check if IsoPlayer is valid and not driving at high speed
             Class<?> playerClass = Class.forName("zombie.characters.IsoPlayer");
             Method getInstMethod = playerClass.getMethod("getInstance");
             Object player = getInstMethod.invoke(null);
 
             if (player == null) {
-                // Main menu or loading screen is always safe
                 return true;
             }
 
-            // Check if player is in a vehicle moving fast
             try {
                 Method getVehicleMethod = playerClass.getMethod("getVehicle");
                 Object vehicle = getVehicleMethod.invoke(player);

--- a/src/com/pzoptimizer/HighPrecisionTimer.java
+++ b/src/com/pzoptimizer/HighPrecisionTimer.java
@@ -1,9 +1,5 @@
 package com.pzoptimizer;
 
-/**
- * Project Zomboid - High Precision Timer & Windows Micro-Sleep Stabilizer.
- * Locks the Windows OS timer resolution to 1.0ms with zero CPU context-switch overhead.
- */
 public class HighPrecisionTimer {
     private static volatile boolean initialized = false;
 

--- a/src/com/pzoptimizer/HordeAnimationLODGovernor.java
+++ b/src/com/pzoptimizer/HordeAnimationLODGovernor.java
@@ -5,19 +5,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 
-/**
- * PZO Dynamic Skeletal Rigging & Animation LOD Governor (Phase 3 SIMD Architecture).
- * 
- * In Build 42, animated 3D models compute 60+ skeletal bone matrix transformations
- * every frame for all active characters in the world regardless of screen visibility.
- * 
- * HordeAnimationLODGovernor dynamically assigns skeletal update fidelity:
- * - Local Players: Always 100% full 60+ FPS fidelity.
- * - Close Zombies (<= 12 tiles): Full multi-track skeletal skinning and blending.
- * - Horde Zombies (> 12 tiles): Uses SharedSkeleAnimationTrack optimization (doBlending = false),
- *   saving redundant 4x4 matrix multiplications with zero visual artifacts.
- * - Guarantees updateBones is always true for active models so zombies never freeze or float.
- */
 public final class HordeAnimationLODGovernor {
 
     private static volatile boolean active = false;
@@ -26,7 +13,6 @@ public final class HordeAnimationLODGovernor {
     public static final AtomicLong boneTransformsSaved = new AtomicLong(0);
     public static final AtomicLong activeModelsTracked = new AtomicLong(0);
 
-    // Cached Reflection Handles
     private static Field modelSlotsField = null;
     private static Field chrField = null;
     private static Field modelField = null;
@@ -90,8 +76,7 @@ public final class HordeAnimationLODGovernor {
     private static void governorLoop() {
         while (active) {
             try {
-                // If player is driving, roadside zombie skeletal LOD is irrelevant and CPU cycles
-                // must be 100% dedicated to chunk decompression and vehicle physics streaming.
+                // Skip the skeletal LOD sweep while driving.
                 if (VehicleTravelOptimizer.isPlayerDriving()) {
                     Thread.sleep(500);
                     continue;
@@ -138,18 +123,11 @@ public final class HordeAnimationLODGovernor {
                 Object animPlayer = animPlayerField.get(model);
                 if (animPlayer == null) continue;
 
-                // CRITICAL FIX: updateBones MUST always be true for any 3D skinned model.
-                // Setting updateBones = false bypasses bone matrix transforms and ragdoll/IK ground placement,
-                // which caused zombies to freeze in static bind-poses and float in the air as 2D sprites.
+                // Keep bone updates enabled: disabling them caused bind poses and incorrect ground placement.
                 updateBonesField.setBoolean(animPlayer, true);
 
-                // Note on doBlending:
-                // We intentionally do NOT force doBlending = false asynchronously from this background thread.
-                // In vanilla PZ (AnimationPlayer.determineCurrentSharedSkeleTrack()), forcing doBlending = false
-                // causes un-cached clips to invoke ModelTransformSampler synchronously on the main thread, baking
-                // 300 animation frames per track and causing massive multi-frame stutter when driving into towns.
-                // Project Zomboid natively and smoothly manages zombie animation blending falloff on the main thread
-                // via PerformanceSettings.numberZombiesBlended in ModelManager.sceneCullZombies().
+                // Leave doBlending to the main thread. Forcing it off can synchronously bake uncached clips
+                // through ModelTransformSampler in determineCurrentSharedSkeleTrack().
             }
         } catch (Throwable ignored) {}
     }

--- a/src/com/pzoptimizer/HordeHibernationEngine.java
+++ b/src/com/pzoptimizer/HordeHibernationEngine.java
@@ -1,12 +1,5 @@
 package com.pzoptimizer;
 
-/**
- * Project Zomboid Build 42 - Distant Horde AI & Spatial Staggering Engine (Phase 3).
- * Staggers expensive pathfinding and sensory checks for distant zombies (>32 tiles)
- * across interleaved frames to eliminate frame drops in high-density zombie towns.
- * 
- * Leverages HordeSpatialCuller's AVX2 multi-tier classification for zero-math O(1) checks.
- */
 public class HordeHibernationEngine {
     private static int frameCounter = 0;
     private static final int HIBERNATION_DISTANCE_SQ = 35 * 35; // 1225 tiles^2
@@ -15,13 +8,11 @@ public class HordeHibernationEngine {
     public static boolean shouldProcessZombieAI(int zombieIndex, int zombieId) {
         int tier = HordeSpatialCuller.getLODTier(zombieIndex);
         if (tier <= 1) {
-            return true; // Close zombies (<32 tiles) always process at full 60 FPS
+            return true;
         } else if (tier == 2) {
-            // Medium-far zombies (32-50 tiles): stagger every 3rd frame
             int slot = Math.abs(zombieId) % 3;
             return (frameCounter % 3) == slot;
         } else {
-            // Out of range (>50 tiles / offscreen): stagger every 6th frame
             int slot = Math.abs(zombieId) % 6;
             return (frameCounter % 6) == slot;
         }
@@ -32,7 +23,6 @@ public class HordeHibernationEngine {
         float dy = zombieY - playerY;
         float distSq = dx * dx + dy * dy;
 
-        // Close-range zombies (<35 tiles) always update every single frame (60 FPS)
         if (distSq < HIBERNATION_DISTANCE_SQ) {
             return true;
         }
@@ -42,7 +32,6 @@ public class HordeHibernationEngine {
             return (frameCounter % 6) == slot;
         }
 
-        // Distant zombies: stagger updates across 3 interleaved frames based on ID
         int slot = Math.abs(zombieId) % 3;
         return (frameCounter % 3) == slot;
     }

--- a/src/com/pzoptimizer/HordePhysicsOptimizer.java
+++ b/src/com/pzoptimizer/HordePhysicsOptimizer.java
@@ -1,10 +1,5 @@
 package com.pzoptimizer;
 
-/**
- * Project Zomboid Build 42 - Horde Spatial Physics & Separation Optimizer.
- * Replaces O(N^2) zombie-to-zombie repulsion calculations with fast squared-distance
- * checks and inverse square-root math to eliminate mega-horde combat lag.
- */
 public class HordePhysicsOptimizer {
 
     public static boolean shouldSeparate(float x1, float y1, float x2, float y2, float maxRadius) {
@@ -13,7 +8,6 @@ public class HordePhysicsOptimizer {
         float maxRadiusSq = maxRadius * maxRadius;
         float distSq = dx * dx + dy * dy;
 
-        // Fast squared-distance early rejection without sqrt
         if (distSq <= 0.0001f || distSq >= maxRadiusSq) {
             return false;
         }

--- a/src/com/pzoptimizer/HordeSpatialCuller.java
+++ b/src/com/pzoptimizer/HordeSpatialCuller.java
@@ -8,27 +8,17 @@ import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-/**
- * PZO SIMD AVX2 Batch Horde Spatial Culler & Vectorized Entity Processor (Phase 3).
- * 
- * Vectorizes spatial proximity checks, camera frustum AABB culling, and multi-tier LOD classification
- * for 500 to 2,000+ active zombies in a single native SIMD pass.
- * 
- * Uses off-heap page-aligned direct NIO buffers from SpatialBufferPool with ZERO garbage collection overhead.
- */
 public final class HordeSpatialCuller {
 
     private static volatile boolean active = false;
     private static Thread cullerThread = null;
 
-    // Telemetry
     public static final AtomicInteger lastTrackedZombieCount = new AtomicInteger(0);
     public static final AtomicInteger lastCulledOffscreenCount = new AtomicInteger(0);
     public static final AtomicInteger lastHibernatingCount = new AtomicInteger(0);
     public static final AtomicLong totalDistanceCalculations = new AtomicLong(0);
     public static final AtomicLong totalBoneTransformsSaved = new AtomicLong(0);
 
-    // Cached Reflection Handles
     private static Field fieldX = null;
     private static Field fieldY = null;
     private static Field fieldZ = null;
@@ -47,14 +37,12 @@ public final class HordeSpatialCuller {
     private static boolean reflectionResolved = false;
     private static boolean reflectionNoticeLogged = false;
 
-    // Internal snapshot storage
     private static final int MAX_SNAPSHOT = SpatialBufferPool.MAX_ENTITIES;
     private static final byte[] SNAPSHOT_TIERS = new byte[MAX_SNAPSHOT];
     private static final byte[] SNAPSHOT_MASK = new byte[MAX_SNAPSHOT];
     private static final float[] SNAPSHOT_DISTANCES = new float[MAX_SNAPSHOT];
     private static volatile int snapshotCount = 0;
 
-    // Thresholds
     public static final float TIER_CLOSE_SQ = 16.0f * 16.0f;     // 256 tiles^2  (LOD 0)
     public static final float TIER_MEDIUM_SQ = 32.0f * 32.0f;   // 1024 tiles^2 (LOD 1)
     public static final float TIER_FAR_SQ = 50.0f * 50.0f;      // 2500 tiles^2 (LOD 2)
@@ -150,7 +138,7 @@ public final class HordeSpatialCuller {
             try {
                 boolean driving = VehicleTravelOptimizer.isPlayerDriving();
                 processSpatialSweep();
-                // Relaxed telemetry sweep: 2 Hz while driving, 4 Hz on foot (eliminates L3 cache contention with main thread)
+                // Sweep at 2 Hz while driving and 4 Hz on foot.
                 Thread.sleep(driving ? 500 : 250);
             } catch (InterruptedException ie) {
                 break;
@@ -169,7 +157,6 @@ public final class HordeSpatialCuller {
 
             if (playerGetInstMethod == null || worldInstField == null) return;
 
-            // 1. Discover local player
             Object player = playerGetInstMethod.invoke(null);
             if (player == null) {
                 lastTrackedZombieCount.set(0);
@@ -180,7 +167,6 @@ public final class HordeSpatialCuller {
             float px = getObjectX(player);
             float py = getObjectY(player);
 
-            // 2. Discover active zombie list from IsoWorld.instance.currentCell
             Object worldInst = worldInstField.get(null);
             if (worldInst == null) return;
 
@@ -208,7 +194,6 @@ public final class HordeSpatialCuller {
             ByteBuffer maskBuf = SpatialBufferPool.getCullMaskBuffer();
             ByteBuffer tiersBuf = SpatialBufferPool.getTiersBuffer();
 
-            // 3. Populate contiguous coordinate buffer
             coordBuf.rewind();
             for (int i = 0; i < count; i++) {
                 if (i >= zombies.size()) break;
@@ -224,21 +209,18 @@ public final class HordeSpatialCuller {
                 }
             }
 
-            // 4. Vectorized AVX2 Batch Calculations
-            // Distance calculation
             PZONative.calculateDistancesAVX2(coordBuf, count, px, py, distBuf);
 
             // Multi-Tier classification (Tier 0: <=256, Tier 1: <=1024, Tier 2: <=2500, Tier 3: >2500)
             PZONative.classifyTiersAVX2(coordBuf, count, px, py, TIER_CLOSE_SQ, TIER_MEDIUM_SQ, TIER_FAR_SQ, tiersBuf);
 
-            // Camera AABB Frustum Culling
             float minX = px - CAMERA_HALF_SPAN;
             float minY = py - CAMERA_HALF_SPAN;
             float maxX = px + CAMERA_HALF_SPAN;
             float maxY = py + CAMERA_HALF_SPAN;
             int insideAABB = PZONative.cullAABBAVX2(coordBuf, count, minX, minY, maxX, maxY, maskBuf);
 
-            // 5. Transfer to snapshot arrays for atomic thread-safe access
+            // Copy results into the shared snapshot arrays.
             distBuf.rewind();
             distBuf.get(SNAPSHOT_DISTANCES, 0, count);
 

--- a/src/com/pzoptimizer/HotSpotJITCompilerTuner.java
+++ b/src/com/pzoptimizer/HotSpotJITCompilerTuner.java
@@ -1,30 +1,22 @@
 package com.pzoptimizer;
 
-/**
- * HotSpot JIT Compiler & JVM Runtime Environment Tuner.
- * Sets runtime system properties to maximize thread concurrency and eliminate JIT compilation lag.
- */
 public class HotSpotJITCompilerTuner {
 
     public static void tuneRuntimeProperties() {
         try {
             int cores = Runtime.getRuntime().availableProcessors();
             
-            // 1. Maximize ForkJoinPool worker concurrency across available CPU cores
             int targetParallelism = Math.max(2, Math.min(16, cores));
             System.setProperty("java.util.concurrent.ForkJoinPool.common.parallelism", String.valueOf(targetParallelism));
             System.setProperty("jdk.virtualThreadScheduler.parallelism", String.valueOf(targetParallelism));
             
-            // 2. Suppress unnecessary AWT/Swing headless redraw interrupts
             System.setProperty("sun.java2d.opengl", "true");
             System.setProperty("sun.java2d.d3d", "false");
             System.setProperty("sun.java2d.noddraw", "true");
             
-            // 3. Enable JVM canonical file path caching (huge reduction in disk path resolution)
             System.setProperty("sun.io.useCanonCaches", "true");
             System.setProperty("sun.io.useCanonPrefixCache", "true");
             
-            // 4. Security random source fast entropy
             System.setProperty("java.security.egd", "file:/dev/urandom");
 
             PZOLogger.info("HotSpotJITCompilerTuner: Runtime properties configured for " + cores + " CPU cores");

--- a/src/com/pzoptimizer/JavaModLoader.java
+++ b/src/com/pzoptimizer/JavaModLoader.java
@@ -20,11 +20,6 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
-/**
- * Project Zomboid Build 42 - Embedded Java & ZombieBuddy Mod Loader.
- * Automatically discovers, deduplicates, classloads, and hooks 3rd-party Java Workshop mods
- * across all mounted Steam libraries and custom mod directories.
- */
 public class JavaModLoader {
     private static final Set<String> LOADED_MODS = new HashSet<>();
     private static int successCount = 0;
@@ -87,7 +82,6 @@ public class JavaModLoader {
         for (File jar : rawJars) {
             String path = jar.getAbsolutePath().replace('\\', '/');
 
-            // Extract Workshop Mod ID if inside /workshop/content/108600/<id>/
             String modKey = jar.getName();
             int wsIdx = path.indexOf("/108600/");
             if (wsIdx != -1) {
@@ -102,7 +96,6 @@ public class JavaModLoader {
             if (existing == null) {
                 modMap.put(modKey, jar);
             } else {
-                // If existing is B41 and new is B42, replace it
                 String existPath = existing.getAbsolutePath().replace('\\', '/');
                 if ((!existPath.contains("42") && path.contains("42")) ||
                     (existPath.contains("42.1") && path.contains("42.2")) ||
@@ -120,7 +113,6 @@ public class JavaModLoader {
         Set<String> scannedDirs = new HashSet<>();
         List<File> searchRoots = new ArrayList<>();
 
-        // 1. User Zomboid mods directory (%USERPROFILE%/Zomboid/mods/)
         try {
             String userHome = System.getProperty("user.home");
             File zomboidMods = new File(userHome, "Zomboid" + File.separator + "mods");
@@ -129,7 +121,6 @@ public class JavaModLoader {
             }
         } catch (Throwable ignored) {}
 
-        // 2. Relative paths from working directory
         try {
             File currentDir = new File(".").getAbsoluteFile();
             File ws1 = new File(currentDir, "../../workshop/content/108600");
@@ -139,7 +130,6 @@ public class JavaModLoader {
             if (ws2.exists() && ws2.isDirectory()) searchRoots.add(ws2);
         } catch (Throwable ignored) {}
 
-        // 3. Scan all mounted drive roots for Steam libraries (C:, D:, E:, K:, etc.)
         try {
             File[] roots = File.listRoots();
             if (roots != null) {
@@ -161,7 +151,6 @@ public class JavaModLoader {
                             }
                         }
 
-                        // Parse libraryfolders.vdf
                         File vdfFile = new File(root, "Program Files (x86)/Steam/steamapps/libraryfolders.vdf".replace('/', File.separatorChar));
                         if (!vdfFile.exists()) {
                             vdfFile = new File(root, "Steam/steamapps/libraryfolders.vdf".replace('/', File.separatorChar));
@@ -174,7 +163,6 @@ public class JavaModLoader {
             }
         } catch (Throwable ignored) {}
 
-        // 4. Unix standard paths
         try {
             String userHome = System.getProperty("user.home");
             File linuxWs = new File(userHome, ".local/share/Steam/steamapps/workshop/content/108600".replace('/', File.separatorChar));
@@ -184,7 +172,6 @@ public class JavaModLoader {
             if (macWs.exists() && macWs.isDirectory()) searchRoots.add(macWs);
         } catch (Throwable ignored) {}
 
-        // 5. Deep scan all discovered search roots (Depth up to 12 levels)
         for (File root : searchRoots) {
             String cPath = getCanonicalPath(root);
             if (!scannedDirs.contains(cPath)) {
@@ -248,7 +235,6 @@ public class JavaModLoader {
         PZOLogger.info(String.format("[JavaModLoader] Inspecting Java mod: %s (%d KB) at %s", jarFile.getName(), sizeKB, jarFile.getPath()));
 
         try (JarFile jar = new JarFile(jarFile)) {
-            // 1. Add JAR to System ClassLoader search path
             if (inst != null) {
                 try {
                     inst.appendToSystemClassLoaderSearch(jar);
@@ -258,7 +244,6 @@ public class JavaModLoader {
                 }
             }
 
-            // 2. Check MANIFEST.MF for Premain-Class, Main-Class, or ZB-Preload
             Manifest manifest = jar.getManifest();
             String agentClass = null;
             if (manifest != null) {
@@ -272,7 +257,6 @@ public class JavaModLoader {
                 }
             }
 
-            // 2. Check for Redundant / Conflicting Bytecode Performance Mods (e.g. Zed Better FPS NG)
             boolean conflictingFpsMod = isConflictingFpsMod(jarFile, agentClass);
             if (!conflictingFpsMod) {
                 Enumeration<JarEntry> testEntries = jar.entries();
@@ -309,7 +293,6 @@ public class JavaModLoader {
                 hooked = invokeEntrypoint(jarFile, agentClass.trim(), inst);
             }
 
-            // 3. Scan class entries for candidate entrypoints (e.g. lugli.optimizations.Main, *Patch, *Plugin)
             if (!hooked) {
                 Enumeration<JarEntry> entries = jar.entries();
                 List<String> candidateClasses = new ArrayList<>();
@@ -322,7 +305,6 @@ public class JavaModLoader {
                     }
                 }
 
-                // Prioritize Main, Plugin, Agent, Patch
                 for (String className : candidateClasses) {
                     if (className.toLowerCase().endsWith(".main") ||
                         className.toLowerCase().contains("plugin") ||
@@ -371,7 +353,6 @@ public class JavaModLoader {
                 clazz = Class.forName(className, true, ucl);
             }
 
-            // 1. Try premain(String, Instrumentation)
             if (inst != null) {
                 try {
                     Method m = clazz.getDeclaredMethod("premain", String.class, Instrumentation.class);
@@ -381,7 +362,6 @@ public class JavaModLoader {
                     return true;
                 } catch (NoSuchMethodException ignored) {}
 
-                // 2. Try premain(String)
                 try {
                     Method m = clazz.getDeclaredMethod("premain", String.class);
                     m.setAccessible(true);
@@ -390,7 +370,6 @@ public class JavaModLoader {
                     return true;
                 } catch (NoSuchMethodException ignored) {}
 
-                // 3. Try agentmain(String, Instrumentation)
                 try {
                     Method m = clazz.getDeclaredMethod("agentmain", String.class, Instrumentation.class);
                     m.setAccessible(true);
@@ -399,7 +378,6 @@ public class JavaModLoader {
                     return true;
                 } catch (NoSuchMethodException ignored) {}
 
-                // 4. Try init(Instrumentation)
                 try {
                     Method m = clazz.getDeclaredMethod("init", Instrumentation.class);
                     m.setAccessible(true);
@@ -409,7 +387,6 @@ public class JavaModLoader {
                 } catch (NoSuchMethodException ignored) {}
             }
 
-            // 5. Try init()
             try {
                 Method m = clazz.getDeclaredMethod("init");
                 m.setAccessible(true);
@@ -418,7 +395,6 @@ public class JavaModLoader {
                 return true;
             } catch (NoSuchMethodException ignored) {}
 
-            // 6. Try load()
             try {
                 Method m = clazz.getDeclaredMethod("load");
                 m.setAccessible(true);
@@ -427,7 +403,6 @@ public class JavaModLoader {
                 return true;
             } catch (NoSuchMethodException ignored) {}
 
-            // 7. Try main(String[])
             try {
                 Method m = clazz.getDeclaredMethod("main", String[].class);
                 m.setAccessible(true);

--- a/src/com/pzoptimizer/KahluaGCPacer.java
+++ b/src/com/pzoptimizer/KahluaGCPacer.java
@@ -1,10 +1,5 @@
 package com.pzoptimizer;
 
-/**
- * Kahlua VM GC Pacing - Passive Mode.
- * Ensures Kahlua Lua memory is managed strictly on the main game thread
- * with zero background thread contention or micro-stutters.
- */
 public class KahluaGCPacer {
     public static void start() {
         // Maintained as passive stub to prevent background Lua thread contention

--- a/src/com/pzoptimizer/LogRotationGuard.java
+++ b/src/com/pzoptimizer/LogRotationGuard.java
@@ -3,10 +3,6 @@ package com.pzoptimizer;
 import java.io.File;
 import java.nio.file.Files;
 
-/**
- * Project Zomboid Build 42 - Zero-Stall Disk I/O & Log Truncation Guard.
- * Cleans up runaway multi-gigabyte console.txt logs from previous modded sessions to keep startup instant.
- */
 public class LogRotationGuard {
     private static final long MAX_LOG_SIZE_BYTES = 15 * 1024 * 1024; // 15 MB
 

--- a/src/com/pzoptimizer/LuaInterpreterAccelerator.java
+++ b/src/com/pzoptimizer/LuaInterpreterAccelerator.java
@@ -4,11 +4,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * Project Zomboid Build 42 - Kahlua Lua Virtual Machine Accelerator.
- * Optimizes Lua global function resolutions, string interning pools, and table key caches
- * without modifying any public Lua API contracts, making 50+ mod setups run 30-40% faster.
- */
 public class LuaInterpreterAccelerator {
     private static final ConcurrentHashMap<String, Object> globalMethodCache = new ConcurrentHashMap<>(256);
     private static volatile boolean active = false;

--- a/src/com/pzoptimizer/ModelSkinningGovernor.java
+++ b/src/com/pzoptimizer/ModelSkinningGovernor.java
@@ -3,19 +3,6 @@ package com.pzoptimizer;
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicLong;
 
-/**
- * PZO Off-Screen Skeletal Skinning Governor (3D Model Animation Culler).
- * 
- * In Project Zomboid Build 42, 3D animated models (zombies, characters, animals) compute
- * full 60+ bone matrix skinning transforms on the CPU every frame for all active entities in the cell.
- * 
- * ModelSkinningGovernor checks whether a 3D model's screen projection is within the visible display frustum
- * (with a 128px safety buffer for wide limb sweeps):
- * - If outside the viewport: skips CPU skeletal skinning matrix recalculations.
- * - If inside the viewport: runs at full 100% native animation fidelity.
- * - Only active in Unstable / Beta channel builds.
- * - Saves millions of matrix multiplications during dense horde encounters.
- */
 public final class ModelSkinningGovernor {
 
     public static final AtomicLong boneTransformsSaved = new AtomicLong(0);
@@ -32,7 +19,6 @@ public final class ModelSkinningGovernor {
 
         updateScreenDimensions();
 
-        // Check if model's screen projection is completely outside screen plus padding
         if (screenX < -PADDING || screenX > (screenWidth + PADDING)
                 || screenY < -PADDING || screenY > (screenHeight + PADDING)) {
             boneTransformsSaved.addAndGet(64); // Average 64 bone transforms per character model

--- a/src/com/pzoptimizer/NativeDirectMemoryPool.java
+++ b/src/com/pzoptimizer/NativeDirectMemoryPool.java
@@ -4,14 +4,9 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-/**
- * PZO Native Direct Memory Pool & Off-Heap Pinned Buffer Ring.
- * Eliminates OS malloc/free page faults during texture loading and world streaming.
- * 100% off-heap, zero-copy, and cross-platform.
- */
 public final class NativeDirectMemoryPool {
 
-    private static final int BUFFER_CAPACITY = 262144; // 256 KB per page-aligned buffer
+    private static final int BUFFER_CAPACITY = 262144; // 256 KB
     private static final int INITIAL_POOL_SIZE = 16;
     private static final ConcurrentLinkedQueue<ByteBuffer> pool = new ConcurrentLinkedQueue<>();
 

--- a/src/com/pzoptimizer/NativeInflater.java
+++ b/src/com/pzoptimizer/NativeInflater.java
@@ -3,12 +3,7 @@ package com.pzoptimizer;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
 
-/**
- * PZO Native SIMD-Accelerated Chunk Decompressor.
- * Extends java.util.zip.Inflater to act as a seamless drop-in replacement for WorldStreamer.
- * Uses AVX2 tinfl in pzo_native64.dll for 50x-100x faster decompression with zero heap allocations.
- * Falls back transparently to JVM Inflater if native library is unavailable or on malformed stream.
- */
+/** Uses native decompression when available, with a JVM Inflater fallback. */
 public class NativeInflater extends Inflater {
 
     private byte[] inputBuffer = null;

--- a/src/com/pzoptimizer/NativeLibraryPreloader.java
+++ b/src/com/pzoptimizer/NativeLibraryPreloader.java
@@ -5,11 +5,6 @@ import java.io.FileInputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Project Zomboid Build 42 - Asynchronous JNI Native Library Preloader.
- * Pre-touches native shared library binary pages into OS virtual memory cache
- * on Thread.MIN_PRIORITY, cutting initial world load freezes by 15-20%.
- */
 public class NativeLibraryPreloader {
     public static void startPreloadingAsync() {
         Thread t = new Thread(() -> {

--- a/src/com/pzoptimizer/NettyBufferPooler.java
+++ b/src/com/pzoptimizer/NettyBufferPooler.java
@@ -1,21 +1,15 @@
 package com.pzoptimizer;
 
-/**
- * Project Zomboid Build 42 - Multiplayer NIO & Zero-Copy Packet Buffer Pooler.
- * Configures off-heap direct byte buffer pooling to eliminate young-gen GC spikes in Multiplayer.
- */
 public class NettyBufferPooler {
     public static void apply() {
         try {
             int cores = Math.max(2, Runtime.getRuntime().availableProcessors());
 
-            // 1. Direct memory buffer pooling for high-throughput packet serialization
             System.setProperty("io.netty.allocator.type", "pooled");
             System.setProperty("io.netty.allocator.numDirectArenas", String.valueOf(cores));
             System.setProperty("io.netty.allocator.numHeapArenas", String.valueOf(Math.max(1, cores / 2)));
             System.setProperty("io.netty.noPreferDirect", "false");
 
-            // 2. High-throughput datagram socket buffers for UDP / Steam networking
             System.setProperty("sun.net.maxDatagramSockets", "1024");
             System.setProperty("java.net.preferIPv4Stack", "true");
 

--- a/src/com/pzoptimizer/PZOConfig.java
+++ b/src/com/pzoptimizer/PZOConfig.java
@@ -3,11 +3,6 @@ package com.pzoptimizer;
 import java.io.File;
 import java.nio.file.Files;
 
-/**
- * PZO Persistent Configuration Manager.
- * Stores user preferences (such as Beta / Unstable build opt-in and ignored versions)
- * into pzo_config.json across Windows, macOS, and Linux.
- */
 public final class PZOConfig {
     private static final String CONFIG_FILE = "pzo_config.json";
     public static final String CURRENT_NOTICE_VERSION = "0.9.6";

--- a/src/com/pzoptimizer/PZOEngineBridge.java
+++ b/src/com/pzoptimizer/PZOEngineBridge.java
@@ -5,10 +5,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
-/**
- * Dedicated Kahlua / LuaManager Java-Lua bridge for Project Zomboid.
- * Exposes native zero-overhead engine diagnostic and optimization methods directly to Lua scripts.
- */
 public class PZOEngineBridge {
 
     private static volatile boolean initialized = false;
@@ -260,9 +256,6 @@ public class PZOEngineBridge {
         }
     }
 
-    /**
-     * Asynchronously discovers and binds to zombie.Lua.LuaManager when Kahlua initializes.
-     */
     public static synchronized void initialize() {
         if (initialized) return;
         initialized = true;
@@ -276,7 +269,6 @@ public class PZOEngineBridge {
                 try {
                     Class<?> lmClass = Class.forName("zombie.Lua.LuaManager");
 
-                    // 1. Try exposer if available
                     try {
                         Field exposerField = lmClass.getField("exposer");
                         Object exposer = exposerField.get(null);
@@ -286,19 +278,16 @@ public class PZOEngineBridge {
                         }
                     } catch (Throwable ignored) {}
 
-                    // 2. Bind directly into LuaManager.env
                     Field envField = lmClass.getField("env");
                     Object env = envField.get(null);
                     if (env != null) {
                         Method rawset = env.getClass().getMethod("rawset", Object.class, Object.class);
 
-                        // Direct boolean and number globals
                         rawset.invoke(env, "PZOEngineActive", Boolean.TRUE);
                         rawset.invoke(env, "isPZOEngineActive", Boolean.TRUE);
                         rawset.invoke(env, "PZOEngineRAM", cachedRamGb);
                         rawset.invoke(env, "PZOEngineVersion", UpdateChecker.CURRENT_VERSION);
 
-                        // Create KahluaTable for PZOEngine and PZOEngineBridge
                         try {
                             Field platformField = lmClass.getField("platform");
                             Object platform = platformField.get(null);
@@ -312,14 +301,12 @@ public class PZOEngineBridge {
                                     tableRawset.invoke(pzoTable, "version", UpdateChecker.CURRENT_VERSION);
                                     tableRawset.invoke(pzoTable, "g1gc", Boolean.TRUE);
 
-                                    // Build dynamic JavaFunction proxies for Kahlua
                                     try {
                                         Class<?> javaFuncClass = Class.forName("se.krka.kahlua.vm.JavaFunction");
                                         Class<?> callFrameClass = Class.forName("se.krka.kahlua.vm.LuaCallFrame");
                                         Method pushObj = callFrameClass.getMethod("push", Object.class);
                                         Method getArg = callFrameClass.getMethod("get", int.class);
 
-                                        // isEnginePresent / isActive
                                         Object isPresentFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -334,7 +321,6 @@ public class PZOEngineBridge {
                                         tableRawset.invoke(pzoTable, "isEnginePresent", isPresentFunc);
                                         tableRawset.invoke(pzoTable, "isActive", isPresentFunc);
 
-                                        // isWindowActive
                                         Object isWindowActiveFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -348,7 +334,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "isWindowActive", isWindowActiveFunc);
 
-                                        // getOptimizedRAM
                                         Object getRamFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -362,7 +347,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "getOptimizedRAM", getRamFunc);
 
-                                        // getVersion
                                         Object getVersionFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -376,7 +360,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "getVersion", getVersionFunc);
 
-                                        // getTelemetryText
                                         Object getTelemetryFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -390,7 +373,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "getTelemetryText", getTelemetryFunc);
 
-                                        // openBrowser
                                         Object openBrowserFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -408,7 +390,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "openBrowser", openBrowserFunc);
 
-                                        // purgeRAM
                                         Object purgeRamFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -422,7 +403,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "purgeRAM", purgeRamFunc);
 
-                                        // getHeapUsedMB
                                         Object getHeapUsedFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -437,7 +417,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "getHeapUsedMB", getHeapUsedFunc);
 
-                                        // getGlCallsFiltered
                                         Object getGlFilteredFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -452,7 +431,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "getGlCallsFiltered", getGlFilteredFunc);
 
-                                        // openLogsFolder
                                         Object openLogsFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -466,7 +444,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "openLogsFolder", openLogsFunc);
 
-                                        // copyDiagnosticsToClipboard
                                         Object copyDiagFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -480,7 +457,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "copyDiagnosticsToClipboard", copyDiagFunc);
 
-                                        // getDiagnosticsReport
                                         Object getDiagReportFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -494,7 +470,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "getDiagnosticsReport", getDiagReportFunc);
 
-                                        // isBetaOptIn
                                         Object isBetaFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -508,7 +483,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "isBetaOptIn", isBetaFunc);
 
-                                        // getChannel
                                         Object getChannelFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -522,7 +496,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "getChannel", getChannelFunc);
 
-                                        // getRenderTelemetry (Unstable channel live metrics)
                                         Object getRenderTelemetryFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -536,7 +509,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "getRenderTelemetry", getRenderTelemetryFunc);
 
-                                        // isAVX2SpatialActive
                                         Object isAVX2SpatialFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -550,7 +522,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "isAVX2SpatialActive", isAVX2SpatialFunc);
 
-                                        // getHordeZombiesTracked
                                         Object getHordeTrackedFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -564,7 +535,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "getHordeZombiesTracked", getHordeTrackedFunc);
 
-                                        // getHordeCulledOffscreen
                                         Object getHordeCulledFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -578,7 +548,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "getHordeCulledOffscreen", getHordeCulledFunc);
 
-                                        // getBoneTransformsSaved
                                         Object getBonesSavedFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -592,7 +561,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "getBoneTransformsSaved", getBonesSavedFunc);
 
-                                        // setBetaOptIn
                                         Object setBetaFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -612,7 +580,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "setBetaOptIn", setBetaFunc);
 
-                                        // checkForUpdates
                                         Object checkUpdateFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -635,7 +602,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "checkForUpdates", checkUpdateFunc);
 
-                                        // setJvmOption
                                         Object setJvmOptionFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -655,7 +621,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "setJvmOption", setJvmOptionFunc);
 
-                                        // setJvmIntOption
                                         Object setJvmIntFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -674,7 +639,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "setJvmIntOption", setJvmIntFunc);
 
-                                        // isMultithreadingNoticeAcknowledged
                                         Object isNoticeAckFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -688,7 +652,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "isMultithreadingNoticeAcknowledged", isNoticeAckFunc);
 
-                                        // acknowledgeMultithreadingNotice
                                         Object ackNoticeFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -702,7 +665,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "acknowledgeMultithreadingNotice", ackNoticeFunc);
 
-                                        // openWorkshopPage
                                         Object openWorkshopFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -716,7 +678,6 @@ public class PZOEngineBridge {
                                         );
                                         tableRawset.invoke(pzoTable, "openWorkshopPage", openWorkshopFunc);
 
-                                        // openGithubPage
                                         Object openGithubFunc = Proxy.newProxyInstance(
                                             javaFuncClass.getClassLoader(),
                                             new Class<?>[]{javaFuncClass},
@@ -737,7 +698,6 @@ public class PZOEngineBridge {
                                     rawset.invoke(env, "PZOEngine", pzoTable);
                                     rawset.invoke(env, "PZOEngineBridge", pzoTable);
 
-                                    // Inject Main Menu Beta Opt-In Tickbox UI into Kahlua
                                     try {
                                         String luaCode =
                                             "local function addPZOBetaToggle()\n" +

--- a/src/com/pzoptimizer/PZOEntrypoint.java
+++ b/src/com/pzoptimizer/PZOEntrypoint.java
@@ -3,10 +3,6 @@ package com.pzoptimizer;
 import java.io.File;
 import java.lang.reflect.Method;
 
-/**
- * Project Zomboid Build 42 - Dedicated High-Performance Engine Optimizer & Wrapper.
- * Fully compatible with vanilla Project Zomboid and ZombieBuddy modding framework.
- */
 public class PZOEntrypoint {
 
     public static void main(String[] args) {
@@ -30,12 +26,10 @@ public class PZOEntrypoint {
         System.setProperty("pzo.optimized", "true");
         System.setProperty("pzo.target", "Build42");
 
-        // Automatically inspect and migrate ProjectZomboid64.json if upgrading from older releases (e.g. 0.8.2 -> 0.9.5)
         try {
             ZomboidConfigMigrator.checkAndMigrateCurrentInstallation(new File(".").getAbsoluteFile());
         } catch (Throwable ignored) {}
 
-        // 0. Native Kernel & Hardware Governor (pzo_native64.dll)
         boolean isNative = false;
         double timerMs = 15.6;
         try {
@@ -45,7 +39,6 @@ public class PZOEntrypoint {
             }
         } catch (Throwable ignored) {}
 
-        // Ensure critical Zomboid user directories exist & write live pzo_status.json across all discovered drives & paths
         try {
             TelemetryReporter.refreshDiscoveredDirectories(args);
             long maxMemMB = Runtime.getRuntime().maxMemory() / (1024 * 1024);
@@ -56,10 +49,8 @@ public class PZOEntrypoint {
             PZOLogger.info("Broadcast live engine status bridge across all user drives and cachedir paths (RAM: " + ramGb + "GB | Native: " + isNative + ")");
         } catch (Throwable ignored) {}
 
-        // HotSpot JIT & System Property Tuning
         HotSpotJITCompilerTuner.tuneRuntimeProperties();
 
-        // 1. Core Memory & Hardware Optimization Modules
         PZOEngineBridge.initialize();
         EngineFeaturesTuner.initializeEngineFeatures();
         EngineThreadGovernor.initialize();
@@ -105,7 +96,6 @@ public class PZOEntrypoint {
         DriverOptimizer.initialize();
         AssetCachePrewarmer.startPrewarmingAsync();
 
-        // 2. StreamBufferBooster & SaveGameStreamBooster (128KB chunk buffers & page-aligned direct NIO)
         try {
             StreamBufferBooster.applyStreamTweaks();
             SaveGameStreamBooster.tuneSaveEngine();
@@ -114,9 +104,6 @@ public class PZOEntrypoint {
             PZOLogger.warn("Non-fatal notice on StreamBufferBooster: " + t.getMessage());
         }
 
-
-
-        // 3. FastMath & VectorPool zero-allocation caches
         try {
             FastMath.sin(0.5f);
             VectorPool.get(0, 0);
@@ -125,7 +112,6 @@ public class PZOEntrypoint {
             PZOLogger.warn("Non-fatal notice on FastMath / VectorPool: " + t.getMessage());
         }
 
-        // 4. GLStateOptimizer & HordePhysicsOptimizer
         try {
             GLStateOptimizer.resetState();
             PZOLogger.success("GLStateOptimizer & HordePhysicsOptimizer ready");
@@ -133,14 +119,12 @@ public class PZOEntrypoint {
             PZOLogger.warn("Non-fatal notice on GLState / HordePhysics: " + t.getMessage());
         }
 
-        // 5. ResourceInterner string deduplication pool
         try {
             PZOLogger.success("ResourceInterner string deduplication pool ready (Max capacity: 16,384 entries)");
         } catch (Throwable t) {
             PZOLogger.warn("Non-fatal notice on ResourceInterner: " + t.getMessage());
         }
 
-        // 6. Pre-Menu Update Check & Interactive Prompt
         boolean fullUpdateHandled = false;
         String resolvedNativeUrl = null;
         try {
@@ -156,7 +140,6 @@ public class PZOEntrypoint {
             PZOLogger.warn("Non-fatal notice on Pre-Menu update checker: " + t.getMessage());
         }
 
-        // 6b. Native Governor DLL Version Verification
         if (!fullUpdateHandled) {
             try {
                 UpdateDialog.checkAndPromptNativeMismatch(resolvedNativeUrl);
@@ -165,12 +148,10 @@ public class PZOEntrypoint {
             }
         }
 
-        // 7. Balanced Game & Streaming Thread Priority
         try {
             Thread.currentThread().setPriority(Thread.NORM_PRIORITY);
         } catch (Throwable ignored) {}
 
-        // 8. Background Telemetry Loop
         Thread watchdog = new Thread(() -> {
             while (true) {
                 try {
@@ -187,7 +168,6 @@ public class PZOEntrypoint {
         watchdog.start();
         PZOLogger.success("PZO-B42-Telemetry monitoring started");
 
-        // 9. Discover and check ZombieBuddy / standalone Java mods
         try {
             boolean zbDetected = false;
             File currentDir = new File(".").getAbsoluteFile();
@@ -215,7 +195,6 @@ public class PZOEntrypoint {
             PZOLogger.warn("[PZO] Non-fatal notice on coexistence check: " + t.getMessage());
         }
 
-        // 10. Launch Project Zomboid Main Entrypoint
         PZOLogger.info("Handing execution over to Project Zomboid entrypoint (zombie.gameStates.MainScreenState)...");
         try {
             Class<?> mainClass = Class.forName("zombie.gameStates.MainScreenState");

--- a/src/com/pzoptimizer/PZOFastMath.java
+++ b/src/com/pzoptimizer/PZOFastMath.java
@@ -1,11 +1,5 @@
 package com.pzoptimizer;
 
-/**
- * PZO Fast Math & L1 Cache-Aligned Trigonometry Engine.
- * Provides single-cycle trigonometric functions, fast inverse square root,
- * and high-speed floating point calculations for physics, angles, and rendering.
- * 100% deterministic, thread-safe, and zero-allocation across Windows, macOS, and Linux.
- */
 public final class PZOFastMath {
 
     private static final int TABLE_SIZE = 65536;

--- a/src/com/pzoptimizer/PZOLogger.java
+++ b/src/com/pzoptimizer/PZOLogger.java
@@ -7,11 +7,6 @@ import java.io.StringWriter;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-/**
- * Project Zomboid Build 42 - Dedicated PZO Engine Logger.
- * Writes real-time initialization statuses, subsystem diagnostics, and crash traces
- * to %USERPROFILE%/Zomboid/Lua/pzo_engine.log and System.out.
- */
 public class PZOLogger {
     private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
     private static File logFile = null;
@@ -31,7 +26,6 @@ public class PZOLogger {
             System.err.println("[PZO-LOGGER-ERR] Failed to initialize log file: " + e.getMessage());
         }
 
-        // Install Global Uncaught Exception Handler for crash capture
         try {
             Thread.UncaughtExceptionHandler defaultHandler = Thread.getDefaultUncaughtExceptionHandler();
             Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {

--- a/src/com/pzoptimizer/PZONative.java
+++ b/src/com/pzoptimizer/PZONative.java
@@ -6,11 +6,6 @@ import java.nio.FloatBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Project Zomboid Build 42 - Dedicated High-Performance Native Kernel & Hardware Governor.
- * Bridges Java to pzo_native64.dll / libpzo_native64.so / libpzo_native64.dylib for low-latency
- * OS scheduling, sub-millisecond timer locking, power throttling exemption, and AVX2 spatial SIMD batching.
- */
 public class PZONative {
 
     private static volatile boolean loaded = false;
@@ -43,13 +38,11 @@ public class PZONative {
     private static synchronized void loadNativeLibrary() {
         if (loaded) return;
 
-        // 1. Try standard Java library path
         try {
             System.loadLibrary("pzo_native64");
             loaded = true;
             PZOLogger.success("[PZONative] Loaded " + NATIVE_LIB_FILENAME + " via System.loadLibrary");
         } catch (Throwable t1) {
-            // 2. Try direct paths relative to working directory or game root
             List<String> candidatePaths = new ArrayList<>();
             candidatePaths.add(NATIVE_LIB_FILENAME);
             candidatePaths.add(System.getProperty("user.dir") + File.separator + NATIVE_LIB_FILENAME);
@@ -104,25 +97,20 @@ public class PZONative {
         if (!initialized) return;
 
         try {
-            // 1. Completely exempt Project Zomboid from Windows 11 EcoQoS Power Throttling
             boolean powerShield = false;
             try { powerShield = disablePowerThrottling(); } catch (Throwable ignored) {}
 
-            // 2. Lock OS Interrupt Timer to 0.5ms high-precision
             boolean timerLock = false;
             try { timerLock = setHighPrecisionTimer(true); } catch (Throwable ignored) {}
 
-            // 3. Register Multimedia Class Scheduler (MMCSS) Games profile
             boolean mmcss = false;
             try { mmcss = setMMCSSProfile("Games"); } catch (Throwable ignored) {}
 
-            // 4. Boost process priority to Above Normal / High and lock working set to physical RAM
             boolean prio = false;
             try { prio = setProcessPriority(1); } catch (Throwable ignored) {}
             boolean wsLock = false;
             try { wsLock = lockProcessWorkingSet(); } catch (Throwable ignored) {}
 
-            // 5. Query hardware topology
             int physCores = 0;
             try { physCores = getPhysicalCores(); } catch (Throwable ignored) {}
             int pCores = 0;
@@ -386,10 +374,6 @@ public class PZONative {
         return count;
     }
 
-    // ========================================================================
-    // Phase 2: High-Speed SIMD Decompression & Win32 Chunk Stream Acceleration
-    // ========================================================================
-
     public static int decompress(byte[] src, int srcOff, int srcLen, byte[] dst, int dstOff, int dstCap) {
         if (!isLoaded() || src == null || dst == null || srcLen <= 0 || dstCap <= 0) return -1;
         try {
@@ -495,9 +479,6 @@ public class PZONative {
         return "Unknown";
     }
 
-    // ========================================================================
-    // Native JNI Declarations (Implemented in pzo_native.c)
-    // ========================================================================
     public static native String getNativeVersion();
     private static native boolean initNative();
     public static native boolean setHighPrecisionTimer(boolean enable);

--- a/src/com/pzoptimizer/PZOTelemetryHUD.java
+++ b/src/com/pzoptimizer/PZOTelemetryHUD.java
@@ -3,11 +3,6 @@ package com.pzoptimizer;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 
-/**
- * PZO Real-Time Telemetry & Diagnostic HUD Bridge.
- * Aggregates runtime engine health, frame time variance, GC pause overhead,
- * off-heap direct buffer allocation, SIMD AVX2 horde culler status, and chunk streaming rates.
- */
 public final class PZOTelemetryHUD {
 
     private static final MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();

--- a/src/com/pzoptimizer/PZOptimAgent.java
+++ b/src/com/pzoptimizer/PZOptimAgent.java
@@ -5,9 +5,6 @@ import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
 import java.security.ProtectionDomain;
 
-/**
- * Project Zomboid Build 42 - Runtime JVM Instrumentation Agent & Java Mod Loader.
- */
 public class PZOptimAgent {
     private static volatile Instrumentation instrumentationInstance = null;
 
@@ -53,7 +50,6 @@ public class PZOptimAgent {
 
         PZOLogger.success("[PZO Agent] Live Bytecode Instrumentation engine attached");
 
-        // Automatically load and hook any ZombieBuddy / Java Workshop mods with full Instrumentation
         try {
             JavaModLoader.loadMods(inst);
         } catch (Throwable t) {
@@ -314,7 +310,6 @@ public class PZOptimAgent {
                     }
                 }
 
-                // class attributes
                 int classAttrCount = dis.readUnsignedShort();
                 dos.writeShort(classAttrCount);
                 for (int a = 0; a < classAttrCount; a++) {
@@ -408,7 +403,6 @@ public class PZOptimAgent {
                 byte[] copy = b.clone();
                 int patchedSites = 0;
 
-                // Loop reduction: calculateZExtentsForChunkMap (28,561 loop down to 169)
                 for (int k = pos; k < copy.length - 4; k++) {
                     if (copy[k] == 0x2A && copy[k + 1] == (byte) 0xB4 &&
                         copy[k + 2] == oldRefHi && copy[k + 3] == oldRefLo &&

--- a/src/com/pzoptimizer/PopTemplateGuard.java
+++ b/src/com/pzoptimizer/PopTemplateGuard.java
@@ -5,29 +5,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Project Zomboid Build 42 - PopTemplateManager Crash Guard & Visual Bounds Shield.
- * 
- * Prevents game-ending exceptions in HumanVisual and CharacterCreationMain:
- * 1. Early Headless Pre-Initialization: Populates PopTemplateManager lists at boot
- *    so background save loading (PlayerDB.loadLocalPlayer) never crashes with
- *    IndexOutOfBoundsException: Index 0 out of bounds for length 0.
- * 2. Strict Vanilla Bounds: Caps maleSkins and femaleSkins to exactly 5 elements so
- *    CharacterCreationMain.lua:652 (self.skinColors[1..5]) is never indexed out of bounds
- *    with 'attempted index: r of non-table: null'.
- * 3. FBO State Safety Guard: Resets TextureFBO.checked if it was probed before the
- *    OpenGL display context was created, preventing ModelManager.create() from aborting
- * 3. GuardedSurvivorMap Interceptor: Replaces IsoGameCharacter.SurvivorMap with a guarded map
- *    that automatically ensures any newly created SurvivorDesc has HumanVisual.skinTextureIndex >= 0.
- *    This completely eliminates CharacterCreationMain.lua:1674 'attempted index: r of non-table: null'
- *    (caused by skinTextureIndex being -1, producing skinColor 0 which indexes nil in Lua).
- * 4. SurvivorFactory Fallback Name Shield: Ensures FemaleForenames, MaleForenames, and Surnames
- *    always contain at least one fallback entry, preventing early CreateSurvivor() from throwing
- *    IndexOutOfBoundsException: Index 0 out of bounds for length 0.
- * 5. FBO State Safety Guard: Resets TextureFBO.checked if it was probed before the
- *    OpenGL display context was created, preventing ModelManager.create() from aborting
- *    with 'FBO not compatible with gfx card at this time'.
- */
+/** Supplies missing survivor defaults and resets FBO probes made before display creation. */
 public class PopTemplateGuard {
 
     private static volatile boolean initialized = false;
@@ -74,7 +52,6 @@ public class PopTemplateGuard {
         resetFBOState();
         obtainUnsafe();
 
-        // 1. PopTemplateManager Skins & Population Guard
         try {
             Class<?> ptmClass = Class.forName("zombie.core.skinnedmodel.population.PopTemplateManager");
             Field instField = ptmClass.getField("instance");
@@ -92,9 +69,7 @@ public class PopTemplateGuard {
                     }
                 }
 
-                // Enforce exact vanilla list sizes:
-                // maleSkins & femaleSkins MUST be exactly 5 items (MaleBody01..05)
-                // so CharacterCreationMain.lua:652 self.skinColors[1..5] is never indexed out-of-bounds!
+                // CharacterCreationMain.lua indexes five skin colors; keep the skin lists at five entries.
                 trimToSize(ptm, "maleSkins", 5, "MaleBody01");
                 trimToSize(ptm, "femaleSkins", 5, "FemaleBody01");
                 trimToSize(ptm, "maleSkinsZombie1", 4, "MaleZombie01");
@@ -118,7 +93,6 @@ public class PopTemplateGuard {
             PZOLogger.warn("[PopTemplateGuard] Non-fatal notice on PopTemplateManager: " + t.getMessage());
         }
 
-        // 2. SurvivorFactory Fallback Names Guard
         try {
             Class<?> sfClass = Class.forName("zombie.characters.SurvivorFactory");
             Field ff = sfClass.getField("FemaleForenames");
@@ -132,13 +106,10 @@ public class PopTemplateGuard {
             if (surnames != null && surnames.isEmpty()) surnames.add("Doe");
         } catch (Throwable ignored) {}
 
-        // 3. Armed GuardedSurvivorMap on IsoGameCharacter.SurvivorMap
         armSurvivorMapGuard();
 
-        // 4. Armed Guard on IsoWorld.instance.survivorDescriptors if active
         armIsoWorldDescriptorsGuard();
 
-        // 5. Sanitize existing survivors
         sanitizeLoadedSurvivors();
     }
 

--- a/src/com/pzoptimizer/PowerThrottlingShield.java
+++ b/src/com/pzoptimizer/PowerThrottlingShield.java
@@ -1,10 +1,5 @@
 package com.pzoptimizer;
 
-/**
- * Project Zomboid Build 42 - CPU Power, Scheduling & Hybrid Core QoS Optimizer.
- * Ensures rendering and physics threads are scheduled onto Performance Cores (P-cores),
- * configures OS multimedia scheduling (MMCSS "Games"), and disables background downclocking.
- */
 public class PowerThrottlingShield {
     public static void apply() {
         try {
@@ -24,19 +19,15 @@ public class PowerThrottlingShield {
 
     private static void applyWindowsQoS() {
         try {
-            // 0. Native kernel governor (EcoQoS exemption, 0.5ms timer, P-core binding)
             if (PZONative.isLoaded()) {
                 PZONative.bindCallingThreadToPCores();
             }
 
-            // 1. Keep JVM working set memory resident when minimized / backgrounded
             System.setProperty("sun.awt.keepWorkingSetOnMinimize", "true");
             System.setProperty("sun.awt.erasebackgroundonresize", "false");
 
-            // 2. High-performance multimedia scheduler and thread factory
             System.setProperty("java.util.concurrent.ForkJoinPool.common.threadFactory", "com.pzoptimizer.ThreadPoolTuner$NamedThreadFactory");
 
-            // 3. Thread group scheduling hints
             System.setProperty("sun.java2d.opengl", "true");
             System.setProperty("sun.java2d.d3d", "false");
 
@@ -46,7 +37,6 @@ public class PowerThrottlingShield {
 
     private static void applyMacQoS() {
         try {
-            // Disable macOS AppNap idle throttling on game loop
             System.setProperty("apple.awt.brushMetalLook", "false");
             System.setProperty("apple.awt.showGrowBox", "false");
             System.setProperty("apple.laf.useScreenMenuBar", "true");
@@ -56,7 +46,6 @@ public class PowerThrottlingShield {
 
     private static void applyLinuxQoS() {
         try {
-            // High-throughput thread scheduler hints for Linux & SteamOS
             System.setProperty("sun.net.useExclusiveBind", "true");
             System.setProperty("java.net.preferIPv4Stack", "true");
             PZOLogger.success("PowerThrottlingShield active (Linux / SteamOS throughput scheduler hints applied)");

--- a/src/com/pzoptimizer/PredictiveChunkStreamer.java
+++ b/src/com/pzoptimizer/PredictiveChunkStreamer.java
@@ -9,16 +9,7 @@ import java.nio.ByteOrder;
 import java.util.HashSet;
 import java.util.Set;
 
-/**
- * PZO Universal Predictive Chunk Streamer (Next-Gen Chunk Streaming Engine).
- * 
- * Tracks player travel mode (driving, sprinting, walking) and proactively registers
- * upcoming chunk coordinates along the velocity vector into ChunkRetentionRing to prevent
- * boundary thrashing and hysteresis unloads.
- * 
- * Operates purely in-memory with zero file-handle locks, eliminating NTFS handle contention
- * with WorldStreamer and ChunkSaveWorker.
- */
+/** Retains and preloads chunks along the player or vehicle travel direction. */
 public final class PredictiveChunkStreamer {
 
     private static volatile boolean running = false;
@@ -77,7 +68,6 @@ public final class PredictiveChunkStreamer {
                         lastPrewarmClearTime = now;
                     }
 
-                    // 1. Discover active player via reflection
                     Class<?> playerClass = Class.forName("zombie.characters.IsoPlayer");
                     Method getInstMethod = playerClass.getMethod("getInstance");
                     Object player = getInstMethod.invoke(null);
@@ -96,7 +86,6 @@ public final class PredictiveChunkStreamer {
                     int currentChunkY = (int) (py / 8.0f);
                     ChunkRetentionRing.touch(currentChunkX, currentChunkY);
 
-                    // 2. Check if player is operating a vehicle
                     Method getVehicleMethod = playerClass.getMethod("getVehicle");
                     Object vehicle = getVehicleMethod.invoke(player);
 
@@ -113,7 +102,7 @@ public final class PredictiveChunkStreamer {
         }, "PZO-PredictiveChunkStreamer");
 
         streamerThread.setDaemon(true);
-        streamerThread.setPriority(Thread.NORM_PRIORITY - 1); // Priority 4 (never competes with gameplay or WorldStreamer)
+        streamerThread.setPriority(Thread.NORM_PRIORITY - 1);
         streamerThread.start();
     }
 
@@ -129,7 +118,7 @@ public final class PredictiveChunkStreamer {
             float dirX = 0.0f;
             float dirY = 0.0f;
 
-            // 1. Try JNI linear velocity vector first (pure physical trajectory, handles drifts and turns)
+            // Prefer physical velocity so prediction follows drifts and turns.
             try {
                 Field velField = vehicle.getClass().getField("jniLinearVelocity");
                 Object velObj = velField.get(vehicle);
@@ -143,7 +132,7 @@ public final class PredictiveChunkStreamer {
                 }
             } catch (Throwable ignored) {}
 
-            // 2. Fallback to vehicle forward vector with speed sign (handles reverses)
+            // Fall back to the forward vector, reversing it for negative speed.
             if (dirX == 0.0f && dirY == 0.0f) {
                 try {
                     Method getForwardVectorMethod = vehicle.getClass().getMethod("getForwardVector", org.joml.Vector3f.class);
@@ -160,7 +149,7 @@ public final class PredictiveChunkStreamer {
                 } catch (Throwable ignored) {}
             }
 
-            // 3. Fallback to player facing direction
+            // Use the player facing direction if vehicle velocity is unavailable.
             if (dirX == 0.0f && dirY == 0.0f) {
                 try {
                     Class<?> playerClass = player.getClass();
@@ -253,7 +242,6 @@ public final class PredictiveChunkStreamer {
         }
         PREWARMED_KEYS.add(key);
 
-        // Preload upcoming chunk data directly into memory cache ahead of vehicle arrival
         if (PRELOADED_CHUNKS.size() < MAX_PRELOADED_CHUNKS) {
             try {
                 if (zombie.iso.IsoChunk.FileExists(wx, wy)) {

--- a/src/com/pzoptimizer/RainAndWeatherOptimizer.java
+++ b/src/com/pzoptimizer/RainAndWeatherOptimizer.java
@@ -3,32 +3,6 @@ package com.pzoptimizer;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-/**
- * Project Zomboid Build 42 - Rain & Weather Travel Performance Optimizer.
- * 
- * Forensically addresses the critical bottlenecks causing major hitching and stuttering
- * while driving in the rain:
- * 
- * 1. Lighting.SplitUpdate Capping:
- *    During rainstorms, thunder and lightning mark chunks dirty in LightingJNI.
- *    Vanilla PZ defaults Lighting.SplitUpdate to false, causing FBORenderCell.updateChunkLighting
- *    to recalculate lighting across ALL 169 chunks in a single frame.
- *    Setting Lighting.SplitUpdate = true caps this to 5 chunks per frame.
- * 
- * 2. Puddle Elevation Floor-Lock:
- *    Vanilla PZ options allow perfPuddles = 0 (All Levels).
- *    FBORenderCell.renderPuddles then scans all chunks across all 32 vertical levels (Z=0 to Z=31)
- *    and issues draw calls for each level.
- *    Restricting perfPuddles to 1 (Ground Floor Only) limits scanning strictly to Z=0,
- *    cutting 97% of redundant upper-floor chunk puddle traversal.
- * 
- * 3. WeatherFxMask Vehicle Bypass:
- *    When driving down roads at high speed, crossing 30-50 squares/sec, WeatherFxMask
- *    invalidates its cache constantly and runs rasterize.scanTriangle across the entire screen,
- *    scanning up to 30,000 mask entries down 32 levels, and performing 4 full-screen FBO render passes.
- *    While the player is driving, WeatherFxMask.maskingEnabled is bypassed so weather particles
- *    render directly without FBO churn, and restored when on foot.
- */
 public final class RainAndWeatherOptimizer {
 
     private static volatile boolean initialized = false;
@@ -49,9 +23,6 @@ public final class RainAndWeatherOptimizer {
         }
     }
 
-    /**
-     * Caps chunk relighting during rain storms to 5 chunks/frame.
-     */
     public static void applyLightingSplitUpdate() {
         try {
             Class<?> debugOptionsClass = Class.forName("zombie.debug.DebugOptions");
@@ -71,9 +42,6 @@ public final class RainAndWeatherOptimizer {
         }
     }
 
-    /**
-     * Enforces ground-level puddles (perfPuddles = 1) if currently set to all 32 levels (0).
-     */
     public static void applyPuddlesElevationCap() {
         try {
             Class<?> coreClass = Class.forName("zombie.core.Core");
@@ -94,9 +62,6 @@ public final class RainAndWeatherOptimizer {
         }
     }
 
-    /**
-     * Ensures WeatherFxMask.maskingEnabled is unconditionally active (prevents raw gray box indoors).
-     */
     private static void ensureWeatherMaskingRestored() {
         try {
             Class<?> maskClass = Class.forName("zombie.iso.weather.fx.WeatherFxMask");

--- a/src/com/pzoptimizer/RenderFrustumCuller.java
+++ b/src/com/pzoptimizer/RenderFrustumCuller.java
@@ -3,17 +3,6 @@ package com.pzoptimizer;
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicLong;
 
-/**
- * PZO Screen-Space Frustum Draw Culler (Build 42 Rendering Acceleration).
- * 
- * Intercepts 2D sprite draw calls before they enter SpriteRenderer command buffers.
- * If a sprite's screen-projected bounding box falls completely outside the active display viewport
- * (with a generous 64px safety bleed margin for tall trees and wall tops), the draw command is discarded.
- * 
- * - Only active in Unstable / Beta channel builds.
- * - Saves CPU command buffer memory and GPU rasterization bandwidth.
- * - 100% thread-safe with real-time atomic telemetry.
- */
 public final class RenderFrustumCuller {
 
     public static final AtomicLong drawCallsCulled = new AtomicLong(0);
@@ -30,7 +19,6 @@ public final class RenderFrustumCuller {
 
         updateScreenDimensions();
 
-        // Check if bounding box is completely outside viewport with bleed margin
         if ((x + width) < -BLEED_MARGIN || x > (screenWidth + BLEED_MARGIN)
                 || (y + height) < -BLEED_MARGIN || y > (screenHeight + BLEED_MARGIN)) {
             drawCallsCulled.incrementAndGet();

--- a/src/com/pzoptimizer/ResourceInterner.java
+++ b/src/com/pzoptimizer/ResourceInterner.java
@@ -2,11 +2,6 @@ package com.pzoptimizer;
 
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * Resource Interner & String Deduplicator.
- * Deduplicates repeated texture filepaths, sound identifiers, and item names
- * across thousands of simulation objects to minimize heap bloat and GC pressure.
- */
 public class ResourceInterner {
     private static final ConcurrentHashMap<String, String> STRING_POOL = new ConcurrentHashMap<>(4096);
     private static final int MAX_POOL_SIZE = 16384;

--- a/src/com/pzoptimizer/SaveGameStreamBooster.java
+++ b/src/com/pzoptimizer/SaveGameStreamBooster.java
@@ -5,12 +5,6 @@ import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.Statement;
 
-/**
- * Project Zomboid Build 42 - Zero-Stutter Chunk & Savegame I/O Accelerator.
- * Enhances background disk streaming for world save files (map_*.bin, zpop_*.bin)
- * and tunes SQLite databases (players.db, vehicles.db) with Write-Ahead Logging (WAL)
- * and 256MB memory-mapped I/O (mmap_size).
- */
 public class SaveGameStreamBooster {
     private static final int OPTIMAL_BUFFER_SIZE = 131072; // 128 KB high-throughput buffer
     private static volatile boolean dbTuned = false;
@@ -21,12 +15,10 @@ public class SaveGameStreamBooster {
 
     public static void tuneSaveEngine() {
         try {
-            // Tune standard I/O buffer properties
             System.setProperty("zomboid.io.buffersize", String.valueOf(OPTIMAL_BUFFER_SIZE));
             PopTemplateGuard.ensurePopulated();
         } catch (Throwable ignored) {}
 
-        // Launch background daemon to apply SQLite WAL mode and memory-mapping when database connections open
         startDbTuningDaemon();
     }
 
@@ -55,7 +47,6 @@ public class SaveGameStreamBooster {
     public static synchronized boolean tuneSqliteDatabases() {
         boolean tunedAny = false;
 
-        // 1. Tune VehiclesDB2
         try {
             Class<?> vdbClass = Class.forName("zombie.vehicles.VehiclesDB2");
             Field instField = vdbClass.getField("instance");
@@ -81,7 +72,6 @@ public class SaveGameStreamBooster {
             }
         } catch (Throwable ignored) {}
 
-        // 2. Tune PlayerDB
         try {
             Class<?> pdbClass = Class.forName("zombie.savefile.PlayerDB");
             Method getInst = pdbClass.getMethod("getInstance");

--- a/src/com/pzoptimizer/SpatialBufferPool.java
+++ b/src/com/pzoptimizer/SpatialBufferPool.java
@@ -4,20 +4,12 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 
-/**
- * PZO Off-Heap Direct Spatial Buffer Pool (Phase 3 SIMD Acceleration).
- * 
- * Pre-allocates dedicated off-heap direct NIO buffers for up to 8,192 concurrent entities.
- * Eliminates all JVM heap allocation and garbage collection overhead during hot-loop
- * horde distance calculations, AABB culling, and LOD classification sweeps.
- */
 public final class SpatialBufferPool {
 
     public static final int MAX_ENTITIES = 8192;
 
     private static volatile boolean initialized = false;
 
-    // Off-heap native memory buffers
     private static ByteBuffer rawCoordBuf;
     private static FloatBuffer coordBuffer;
 
@@ -39,32 +31,24 @@ public final class SpatialBufferPool {
         if (initialized) return;
 
         try {
-            // 8,192 entities * 2 coordinates (x,y) * 4 bytes/float = 65,536 bytes (64 KB)
             rawCoordBuf = ByteBuffer.allocateDirect(MAX_ENTITIES * 2 * Float.BYTES).order(ByteOrder.nativeOrder());
             coordBuffer = rawCoordBuf.asFloatBuffer();
 
-            // 8,192 entities * 4 bytes/float = 32,768 bytes (32 KB)
             rawDistanceBuf = ByteBuffer.allocateDirect(MAX_ENTITIES * Float.BYTES).order(ByteOrder.nativeOrder());
             distanceBuffer = rawDistanceBuf.asFloatBuffer();
 
-            // 8,192 entities * 4 bytes/float = 32,768 bytes (32 KB)
             rawDistSqBuf = ByteBuffer.allocateDirect(MAX_ENTITIES * Float.BYTES).order(ByteOrder.nativeOrder());
             distSqBuffer = rawDistSqBuf.asFloatBuffer();
 
-            // 8,192 entities * 1 byte = 8,192 bytes (8 KB)
             cullMaskBuffer = ByteBuffer.allocateDirect(MAX_ENTITIES).order(ByteOrder.nativeOrder());
 
-            // 8,192 entities * 1 byte = 8,192 bytes (8 KB)
             tiersBuffer = ByteBuffer.allocateDirect(MAX_ENTITIES).order(ByteOrder.nativeOrder());
 
-            // 8,192 entities * 2 heading unit vectors (hx, hy) * 4 bytes = 65,536 bytes (64 KB)
             rawHeadingBuf = ByteBuffer.allocateDirect(MAX_ENTITIES * 2 * Float.BYTES).order(ByteOrder.nativeOrder());
             headingBuffer = rawHeadingBuf.asFloatBuffer();
 
-            // 8,192 entities * 1 byte = 8,192 bytes (8 KB)
             fovMaskBuffer = ByteBuffer.allocateDirect(MAX_ENTITIES).order(ByteOrder.nativeOrder());
 
-            // 8,192 entities * 2 repulsion forces (fx, fy) * 4 bytes = 65,536 bytes (64 KB)
             rawRepulsionBuf = ByteBuffer.allocateDirect(MAX_ENTITIES * 2 * Float.BYTES).order(ByteOrder.nativeOrder());
             repulsionBuffer = rawRepulsionBuf.asFloatBuffer();
 

--- a/src/com/pzoptimizer/SpriteBatchOptimizer.java
+++ b/src/com/pzoptimizer/SpriteBatchOptimizer.java
@@ -1,15 +1,10 @@
 package com.pzoptimizer;
 
-/**
- * Project Zomboid Build 42 - Zero-Allocation 2D/3D Sprite Batch Optimizer.
- * Optimizes vertex buffer submissions and state flushing to eliminate 1% low frame stutter.
- */
 public class SpriteBatchOptimizer {
     private static boolean active = false;
 
     public static void apply() {
         try {
-            // Configure LWJGL and NIO memory buffers for zero-copy vertex arrays
             System.setProperty("org.lwjgl.util.NoChecks", "true");
             System.setProperty("org.lwjgl.util.NoArrayChecks", "true");
             System.setProperty("pzo.sprite.batching", "true");

--- a/src/com/pzoptimizer/StreamBufferBooster.java
+++ b/src/com/pzoptimizer/StreamBufferBooster.java
@@ -1,25 +1,17 @@
 package com.pzoptimizer;
 
-/**
- * Build 42 Direct Memory & NIO Stream Acceleration.
- * Configures per-thread direct buffer caches and CPU core worker concurrency.
- */
 public class StreamBufferBooster {
 
     public static void applyStreamTweaks() {
         try {
-            // Enable canonical file path caching in JVM
             System.setProperty("sun.io.useCanonCaches", "true");
             System.setProperty("sun.io.useCanonPrefixCache", "true");
 
-            // Java 17 NIO Direct Memory cache (256 KB per thread buffer)
             System.setProperty("jdk.nio.maxCachedBufferSize", "262144");
 
-            // Concurrency scaling for background async loaders
             int cores = Runtime.getRuntime().availableProcessors();
             System.setProperty("java.util.concurrent.ForkJoinPool.common.parallelism", String.valueOf(Math.max(4, cores)));
 
-            // High-throughput network DNS cache timeout for MP servers
             System.setProperty("sun.net.inetaddr.ttl", "60");
         } catch (Throwable ignored) {}
     }

--- a/src/com/pzoptimizer/TelemetryReporter.java
+++ b/src/com/pzoptimizer/TelemetryReporter.java
@@ -21,7 +21,6 @@ public class TelemetryReporter {
 
     public static void refreshDiscoveredDirectories(String[] cliArgs) {
         try {
-            // 1. Check CLI args for -cachedir
             if (cliArgs != null) {
                 for (int i = 0; i < cliArgs.length; i++) {
                     String arg = cliArgs[i];
@@ -36,7 +35,6 @@ public class TelemetryReporter {
                 }
             }
 
-            // 2. System properties and environment variables
             String propCache = System.getProperty("zomboid.cachedir");
             if (propCache != null && !propCache.trim().isEmpty()) {
                 registerZomboidDir(new File(propCache.trim()));
@@ -47,7 +45,6 @@ public class TelemetryReporter {
                 registerZomboidDir(new File(envCache.trim()));
             }
 
-            // 3. User Home, UserProfile, Documents & OneDrive
             String userHome = System.getProperty("user.home");
             if (userHome != null) {
                 registerZomboidDir(new File(userHome, "Zomboid"));
@@ -62,11 +59,9 @@ public class TelemetryReporter {
                 registerZomboidDir(new File(userProfile, "OneDrive" + File.separator + "Documents" + File.separator + "Zomboid"));
             }
 
-            // 4. Working directory
             registerZomboidDir(new File("Zomboid"));
             registerZomboidDir(new File("."));
 
-            // 5. Scan all mounted drive roots (D:\, E:\, F:\, etc.)
             try {
                 File[] roots = File.listRoots();
                 if (roots != null) {
@@ -81,7 +76,6 @@ public class TelemetryReporter {
                 }
             } catch (Throwable ignored) {}
 
-            // 6. Dynamic Reflection into zombie.ZomboidFileSystem
             queryZomboidFileSystem();
 
         } catch (Throwable ignored) {}

--- a/src/com/pzoptimizer/ThreadPoolTuner.java
+++ b/src/com/pzoptimizer/ThreadPoolTuner.java
@@ -1,15 +1,9 @@
 package com.pzoptimizer;
 
-/**
- * Hardware-Adaptive CPU Thread Pool & Parallelism Tuner.
- * Dynamically scales ForkJoinPool and worker pools to match physical CPU performance cores
- * without overloading low-end dual-core or thermal-throttled laptop CPUs.
- */
 public class ThreadPoolTuner {
     public static void initialize() {
         try {
             int availableCores = Runtime.getRuntime().availableProcessors();
-            // Clamp safely between 2 and 16 cores (100% stable across all hardware)
             int targetParallelism = Math.max(2, Math.min(16, availableCores));
 
             System.setProperty("java.util.concurrent.ForkJoinPool.common.parallelism", String.valueOf(targetParallelism));

--- a/src/com/pzoptimizer/UnstableChannelGuard.java
+++ b/src/com/pzoptimizer/UnstableChannelGuard.java
@@ -1,13 +1,5 @@
 package com.pzoptimizer;
 
-/**
- * PZO Unstable Channel Gatekeeper.
- * 
- * Enforces strict channel isolation:
- * Experimental rendering optimizations and advanced telemetry collectors ONLY run
- * when operating on the Unstable / Beta channel.
- * In standard stable production releases, these modules remain 100% dormant no-ops.
- */
 public final class UnstableChannelGuard {
 
     private static volatile Boolean cachedIsUnstable = null;

--- a/src/com/pzoptimizer/UpdateChecker.java
+++ b/src/com/pzoptimizer/UpdateChecker.java
@@ -11,11 +11,6 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * PZO Multi-Channel Update Checker.
- * Supports strict channel isolation between Stable (releases/latest) and Beta/Unstable (releases list).
- * 100% pure Java with zero external dependencies.
- */
 public class UpdateChecker {
     public static final String CURRENT_VERSION = "0.9.6";
     private static final String GITHUB_LATEST_API_URL = "https://api.github.com/repos/prop11/PZO-Launcher/releases/latest";
@@ -85,7 +80,7 @@ public class UpdateChecker {
                     releases.add(json);
                 }
 
-                // Pass 1: Look for exact tag or version match
+                // Prefer an exact tag or version match.
                 for (String relJson : releases) {
                     if (extractJsonBooleanField(relJson, "draft")) continue;
                     String tag = extractJsonField(relJson, "tag_name");
@@ -104,7 +99,7 @@ public class UpdateChecker {
                     }
                 }
 
-                // Pass 2: Look for highest compatible release on the channel containing native asset
+                // Otherwise select the highest compatible release containing a native asset.
                 for (String relJson : releases) {
                     if (extractJsonBooleanField(relJson, "draft")) continue;
                     boolean isPrerelease = extractJsonBooleanField(relJson, "prerelease");
@@ -179,7 +174,6 @@ public class UpdateChecker {
             String selectedReleaseJson = null;
 
             if (json.startsWith("[")) {
-                // Parse array of releases and find the highest available version matching channel
                 List<String> releases = splitJsonArrayObjects(json);
                 String bestRelJson = null;
                 String bestVersion = null;
@@ -194,7 +188,6 @@ public class UpdateChecker {
                     boolean hasUnstableTag = isUnstableIdentifier(tag) || isUnstableIdentifier(name);
 
                     if (!betaOptIn) {
-                        // NORMAL (STABLE) USER: Strictly reject all prereleases and unstable/beta tagged builds
                         if (isPrerelease || hasUnstableTag) {
                             continue;
                         }
@@ -213,13 +206,11 @@ public class UpdateChecker {
                 }
                 selectedReleaseJson = bestRelJson;
             } else if (json.startsWith("{")) {
-                // Single release object (e.g. from /releases/latest)
                 boolean isPrerelease = extractJsonBooleanField(json, "prerelease");
                 String tag = extractJsonField(json, "tag_name");
                 String name = extractJsonField(json, "name");
                 boolean hasUnstableTag = isUnstableIdentifier(tag) || isUnstableIdentifier(name);
 
-                // Safety guard: If normal user somehow received an unstable release, reject it
                 if (!betaOptIn && (isPrerelease || hasUnstableTag)) {
                     writeStatus(false, CURRENT_VERSION, res.channel);
                     return res;
@@ -284,9 +275,6 @@ public class UpdateChecker {
         }
     }
 
-    /**
-     * Identifies tags or release titles denoting unstable/beta/preview builds.
-     */
     public static boolean isUnstableIdentifier(String text) {
         if (text == null || text.isEmpty()) return false;
         String lower = text.toLowerCase();

--- a/src/com/pzoptimizer/UpdateDialog.java
+++ b/src/com/pzoptimizer/UpdateDialog.java
@@ -7,10 +7,6 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Project Zomboid Build 42 - Pre-Menu Native Interactive Update Prompt & Self-Updater.
- * Multi-Platform: Windows (WinForms), macOS (Cocoa/AppleScript), Linux & Steam Deck (Zenity/KDialog).
- */
 public class UpdateDialog {
     private static final String CONFIG_FILE = "pzo_config.json";
 
@@ -47,16 +43,11 @@ public class UpdateDialog {
         return false;
     }
 
-    /**
-     * Checks if a native governor library exists in the game folder and verifies whether its
-     * version matches the Java mod version. If missing, mismatched, or outdated, prompts the user to download.
-     */
     public static boolean checkAndPromptNativeMismatch(String dllDownloadUrl) {
         boolean filePresent = PZONative.isNativeFilePresent();
         String installedVersion = PZONative.getInstalledNativeVersion();
         String expectedVersion = UpdateChecker.CURRENT_VERSION;
 
-        // If file is present and versions match, native library is up-to-date and fully compatible
         if (filePresent && expectedVersion.equalsIgnoreCase(installedVersion)) {
             return false;
         }
@@ -185,7 +176,6 @@ public class UpdateDialog {
     }
 
     private static String showLinuxDialog(String latestVersion) {
-        // 1. Try Zenity (GNOME, Ubuntu, Mint, Pop!_OS)
         try {
             Process p = new ProcessBuilder("zenity", "--question",
                 "--title=PZO Engine - Update Available",
@@ -203,7 +193,6 @@ public class UpdateDialog {
             return "SKIP";
         } catch (Throwable ignored) {}
 
-        // 2. Try KDialog (Steam Deck / KDE Plasma default)
         try {
             Process p = new ProcessBuilder("kdialog",
                 "--title", "PZO Engine - Update Available",
@@ -376,7 +365,6 @@ public class UpdateDialog {
             File currentNative = new File(gameDir, nativeFileName);
             File newNative = new File(gameDir, nativeFileName + ".new");
 
-            // Build prioritized candidate URL list
             List<String> candidateUrls = new ArrayList<>();
             if (dllDownloadUrl != null && !dllDownloadUrl.isEmpty() && !dllDownloadUrl.contains("/releases/latest/")) {
                 candidateUrls.add(dllDownloadUrl);
@@ -426,7 +414,7 @@ public class UpdateDialog {
             long pid = ProcessHandle.current().pid();
             File win64Dll = new File(gameDir, "win64" + File.separator + nativeFileName);
 
-            // Stage ProjectZomboid64.json update if missing required 0.9.5 flags (such as -agentlib:pzo_native64)
+            // Stage configuration changes for replacement after the game exits.
             File currentJson = new File(gameDir, ZomboidConfigMigrator.TARGET_JSON_NAME);
             File newJson = new File(gameDir, ZomboidConfigMigrator.TARGET_JSON_NAME + ".new");
             boolean hasNewJson = ZomboidConfigMigrator.prepareStagedUpdate(gameDir) && newJson.exists();
@@ -494,7 +482,6 @@ public class UpdateDialog {
                 );
                 new ProcessBuilder("bash", "-c", shUpdater).start();
             } else {
-                // Linux & Steam Deck
                 String linuxJsonUpdate = hasNewJson ? String.format(
                     " && (test -f \"%s\" && mv -f \"%s\" \"%s\" || true)",
                     newJson.getAbsolutePath(), newJson.getAbsolutePath(), currentJson.getAbsolutePath()
@@ -547,7 +534,6 @@ public class UpdateDialog {
             String cleanVer = latestVersion != null ? latestVersion.trim() : UpdateChecker.CURRENT_VERSION;
             String vTag = cleanVer.startsWith("v") || cleanVer.startsWith("V") ? cleanVer : "V" + cleanVer;
 
-            // Handle Native Companion Library (.dll / .so / .dylib)
             String os = System.getProperty("os.name", "").toLowerCase();
             boolean isWin = os.contains("win");
             boolean isMac = os.contains("mac") || os.contains("darwin");
@@ -559,7 +545,7 @@ public class UpdateDialog {
             boolean nativeInstalled = PZONative.isNativeFilePresent() || currentNative.exists() || win64Dll.exists();
             boolean hasNewNative = false;
 
-            // Step 1: Download matching native companion library first if native governor is installed or supported
+            // Download the matching native library before the JAR.
             List<String> nativeCandidates = new ArrayList<>();
             if (dllDownloadUrl != null && !dllDownloadUrl.isEmpty() && !dllDownloadUrl.contains("/releases/latest/")) {
                 nativeCandidates.add(dllDownloadUrl);
@@ -588,7 +574,7 @@ public class UpdateDialog {
                 }
             }
 
-            // CRITICAL: If native governor is installed on user's system, we MUST NOT perform a partial update!
+            // Abort if the installed native library cannot be updated with the JAR.
             if (nativeInstalled && !hasNewNative) {
                 if (newNative.exists()) newNative.delete();
                 PZOLogger.error("Failed to download matching native library (" + nativeFileName + ") for version " + latestVersion + ". Aborting update to avoid library mismatch.");
@@ -596,7 +582,6 @@ public class UpdateDialog {
                 return;
             }
 
-            // Step 2: Download PZOptimEngine.jar
             List<String> jarCandidates = new ArrayList<>();
             if (downloadUrl != null && !downloadUrl.isEmpty() && !downloadUrl.contains("/releases/latest/")) {
                 jarCandidates.add(downloadUrl);
@@ -626,7 +611,7 @@ public class UpdateDialog {
 
             long pid = ProcessHandle.current().pid();
 
-            // Stage ProjectZomboid64.json update if missing required 0.9.5 flags (such as -agentlib:pzo_native64)
+            // Stage configuration changes for replacement after the game exits.
             File currentJson = new File(gameDir, ZomboidConfigMigrator.TARGET_JSON_NAME);
             File newJson = new File(gameDir, ZomboidConfigMigrator.TARGET_JSON_NAME + ".new");
             boolean hasNewJson = ZomboidConfigMigrator.prepareStagedUpdate(gameDir) && newJson.exists();
@@ -710,7 +695,6 @@ public class UpdateDialog {
                 );
                 new ProcessBuilder("bash", "-c", shUpdater).start();
             } else {
-                // Linux & Steam Deck
                 String linuxJsonUpdate = hasNewJson ? String.format(
                     " && (test -f \"%s\" && mv -f \"%s\" \"%s\" || true)",
                     newJson.getAbsolutePath(), newJson.getAbsolutePath(), currentJson.getAbsolutePath()

--- a/src/com/pzoptimizer/VectorPool.java
+++ b/src/com/pzoptimizer/VectorPool.java
@@ -1,10 +1,5 @@
 package com.pzoptimizer;
 
-/**
- * Thread-Local Vector & Coordinate Pool.
- * Eliminates temporary 3D/2D vector allocations in high-frequency raycasting,
- * horde spatial queries, and line-of-sight math.
- */
 public class VectorPool {
 
     public static class Vec2 {

--- a/src/com/pzoptimizer/VehicleTrajectoryStreamer.java
+++ b/src/com/pzoptimizer/VehicleTrajectoryStreamer.java
@@ -1,10 +1,6 @@
 package com.pzoptimizer;
 
-/**
- * PZO Predictive Vehicle Trajectory & Chunk Stream Accelerator.
- * Subsumed and upgraded by PredictiveChunkStreamer for universal walking, sprinting, and driving acceleration.
- * Maintained as a seamless delegator for backward compatibility.
- */
+/** Compatibility entry point delegating to PredictiveChunkStreamer. */
 public final class VehicleTrajectoryStreamer {
 
     public static void start() {

--- a/src/com/pzoptimizer/VehicleTravelOptimizer.java
+++ b/src/com/pzoptimizer/VehicleTravelOptimizer.java
@@ -6,22 +6,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.locks.ReentrantLock;
 import sun.misc.Unsafe;
 
-/**
- * Project Zomboid Build 42 - Vehicle Travel & High-Speed Chunk Streaming Optimizer.
- * 
- * Solves the primary architectural root causes of vehicle stutter in Build 42:
- * 1. IsoChunkMap Fair-Lock Bottleneck:
- *    Vanilla PZ declares `public static final ReentrantLock bSettingChunk = new ReentrantLock(true);`.
- *    A fair lock enforces strict FIFO queueing across threads (MainThread, WorldStreamer, LightingThread).
- *    This causes extreme thread context switching and OS descheduling whenever chunks are stitched.
- *    VehicleTravelOptimizer reflectively replaces this with a non-fair atomic lock (10x-50x throughput).
- * 
- * 2. ChunkSaveWorker Main-Thread Hotsave Hitch:
- *    When driving fast, trailing chunks unload and enter ChunkSaveWorker.toSaveQueue.
- *    Whenever the save queue empties, ChunkSaveWorker invokes HotsaveAncilliarySystems() on the MAIN THREAD,
- *    freezing the game for 50-150ms to serialize the entire MetaGrid, World Map, Animals, and GameEntities.
- *    VehicleTravelOptimizer shields toSaveQueue so ancillary hotsaves are deferred during vehicle travel.
- */
 public final class VehicleTravelOptimizer {
 
     private static volatile boolean initialized = false;
@@ -38,7 +22,6 @@ public final class VehicleTravelOptimizer {
 
     public static final java.util.concurrent.atomic.AtomicLong throttledTownZombies = new java.util.concurrent.atomic.AtomicLong(0);
 
-    // Minimum cooldown between ancillary systems hotsaves (60 seconds)
     private static final long ANCILLARY_HOTSAVE_COOLDOWN_MS = 60_000L;
 
     public static synchronized void initialize() {
@@ -74,9 +57,6 @@ public final class VehicleTravelOptimizer {
         }
     }
 
-    /**
-     * 1. Replaces IsoChunkMap.bSettingChunk fair lock with a high-throughput non-fair lock.
-     */
     public static synchronized boolean installUnfairChunkLock() {
         if (unfairLockInstalled) return true;
         obtainUnsafe();
@@ -109,10 +89,6 @@ public final class VehicleTravelOptimizer {
         return false;
     }
 
-    /**
-     * 2. Replaces ChunkSaveWorker.toSaveQueue with a shielded queue that defers main-thread
-     *    ancillary hotsaves while the player is operating a vehicle.
-     */
     public static synchronized boolean installSaveWorkerShield() {
         if (saveShieldInstalled) return true;
         obtainUnsafe();
@@ -274,12 +250,6 @@ public final class VehicleTravelOptimizer {
         return System.identityHashCode(obj);
     }
 
-    /**
-     * 3. Installs a dynamic entity simulation governor into MovingObjectUpdateScheduler.
-     * Intercepts the FULL simulation bucket (where 500+ alerted town zombies are dumped by engine sound)
-     * and redirects distant zombies (> 20 tiles) to QUARTER (15 FPS) and EIGHTH (7.5 FPS) simulation,
-     * dropping main-thread pathfinding and collision overhead by 75-85% during vehicle travel.
-     */
     public static synchronized boolean installSimulationGovernor() {
         if (simulationGovernorInstalled) return true;
 
@@ -314,7 +284,6 @@ public final class VehicleTravelOptimizer {
             GovernedSimulationList governed = new GovernedSimulationList(fullBuckets[0], quarterBuckets, eighthBuckets);
             fullBuckets[0] = governed;
 
-            // Also shield HALF simulation bucket (index 1)
             @SuppressWarnings("unchecked")
             java.util.List<Object>[] halfBuckets = (java.util.List<Object>[]) bucketsField.get(simLevels[1]);
             if (halfBuckets != null) {
@@ -334,9 +303,6 @@ public final class VehicleTravelOptimizer {
         return false;
     }
 
-    /**
-     * Specialized ArrayList that intercepts MovingObjectUpdateScheduler FULL bucket distribution.
-     */
     public static final class GovernedSimulationList extends java.util.ArrayList<Object> {
         private static final long serialVersionUID = 4243L;
 
@@ -365,14 +331,12 @@ public final class VehicleTravelOptimizer {
                 float dy = zy - py;
                 float distSq = dx * dx + dy * dy;
 
-                // Close-range zombies (<= 20 tiles): Keep in FULL 60 FPS for responsive combat and vehicle bumper physics
                 if (distSq <= 400.0f) {
                     return super.add(obj);
                 }
 
                 int id = getObjectId(obj);
 
-                // Mid-range zombies (20 to 50 tiles): Redirect to QUARTER simulation (15 FPS updates interleaved)
                 if (distSq <= 2500.0f && quarterBuckets != null && quarterBuckets.length > 0) {
                     int slot = (id & 0x7FFFFFFF) % quarterBuckets.length;
                     quarterBuckets[slot].add(obj);
@@ -380,7 +344,6 @@ public final class VehicleTravelOptimizer {
                     return true;
                 }
 
-                // Distant town zombies (> 50 tiles): Redirect to EIGHTH simulation (7.5 FPS updates interleaved)
                 if (eighthBuckets != null && eighthBuckets.length > 0) {
                     int slot = (id & 0x7FFFFFFF) % eighthBuckets.length;
                     eighthBuckets[slot].add(obj);
@@ -393,11 +356,7 @@ public final class VehicleTravelOptimizer {
         }
     }
 
-    /**
-     * Specialized ConcurrentLinkedQueue that monitors ChunkSaveWorker chunk drains.
-     * Intercepts isEmpty() right after poll() to defer 150ms HotsaveAncilliarySystems()
-     * during active vehicle operation, while keeping saving=false and normal saves 100% functional.
-     */
+    /** Overrides isEmpty() after a chunk drain to defer ancillary hotsaves while driving. */
     public static final class ShieldedSaveQueue extends ConcurrentLinkedQueue<Object> {
         private static final long serialVersionUID = 4242L;
 
@@ -425,7 +384,7 @@ public final class VehicleTravelOptimizer {
                 if (isPlayerDriving()) {
                     long now = System.currentTimeMillis();
                     if (now - lastAncillaryHotsaveTime < ANCILLARY_HOTSAVE_COOLDOWN_MS) {
-                        // Defer 150ms HotsaveAncilliarySystems() freeze while operating vehicle!
+                        // Defer HotsaveAncilliarySystems() while driving.
                         return false;
                     }
                     lastAncillaryHotsaveTime = now;

--- a/src/com/pzoptimizer/VerticalChunkStreamer.java
+++ b/src/com/pzoptimizer/VerticalChunkStreamer.java
@@ -3,14 +3,6 @@ package com.pzoptimizer;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
-/**
- * PZO Build 42 32-Level Vertical (Z-Index) Chunk Pre-caching Streamer.
- * Build 42 expands vertical world height from 8 levels to 32 levels (-16 to +16).
- * 
- * This streamer tracks player vertical velocity and staircase transitions,
- * predictively pre-warming vertical chunk slices and grid square lookups
- * to eliminate stair climbing and high-rise elevator hitching.
- */
 public final class VerticalChunkStreamer {
 
     private static volatile boolean active = false;
@@ -64,11 +56,9 @@ public final class VerticalChunkStreamer {
                 lastPlayerZ = currentZ;
                 lastZChangeTime = System.currentTimeMillis();
 
-                // Predictively warm adjacent vertical slices (currentZ + zDelta, currentZ + 2*zDelta)
                 int targetZ1 = currentZ + zDelta;
                 int targetZ2 = currentZ + (zDelta * 2);
 
-                // Ensure within Build 42 bounds (-16 to +16)
                 if (targetZ1 >= -16 && targetZ1 <= 16) {
                     prewarmVerticalLevel(player, targetZ1);
                 }
@@ -100,7 +90,6 @@ public final class VerticalChunkStreamer {
             int px = (int) ((Number) getX.invoke(player)).floatValue();
             int py = (int) ((Number) getY.invoke(player)).floatValue();
 
-            // Query grid squares in 5x5 column around player on target Z level
             Method getGridSquare = cell.getClass().getMethod("getGridSquare", int.class, int.class, int.class);
             for (int dx = -2; dx <= 2; dx++) {
                 for (int dy = -2; dy <= 2; dy++) {

--- a/src/com/pzoptimizer/WorldStreamerBooster.java
+++ b/src/com/pzoptimizer/WorldStreamerBooster.java
@@ -3,26 +3,13 @@ package com.pzoptimizer;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 
-/**
- * WorldStreamer Thread Priority & Chunk Bandwidth Booster.
- * Elevates the "World Streamer" and "Lighting" thread priorities so the OS never starves
- * disk and chunk decompression workers while the player is driving fast in vehicles.
- * 
- * Phase 2:
- * - Upgrades WorldStreamer.instance.decompressor to NativeInflater (SIMD AVX2 zlib inflate).
- * - Upgrades WorldStreamer.instance.readBuf from 1KB to 256KB (60x reduction in JNI loop transitions).
- * - Pre-allocates WorldStreamer.instance.inMemoryZip to 512KB (zero reallocation garbage).
- * - Upgrades IsoChunk.sliceBufferLoad from 64KB to 1MB (eliminates 100% disk buffer reallocations).
- */
 public class WorldStreamerBooster {
 
     private static volatile boolean streamBoosterInstalled = false;
 
     public static void startDaemon() {
-        // Start predictive vehicle trajectory streaming daemon
         VehicleTrajectoryStreamer.start();
 
-        // 0. Enforce IsoChunkMap parity once at boot
         try {
             ChunkCrashShield.enforceChunkGridSanity();
         } catch (Throwable ignored) {}
@@ -37,7 +24,7 @@ public class WorldStreamerBooster {
                     EngineFeaturesTuner.reapplyRuntimeTuning();
                     installStreamBooster();
 
-                    // 1. Maintain WorldStreamer thread at NORM_PRIORITY (prevents main-thread rendering preemption)
+                    // Keep WorldStreamer at normal priority to avoid preempting rendering.
                     Class<?> wsClass = Class.forName("zombie.iso.WorldStreamer");
                     Field instField = wsClass.getField("instance");
                     Object wsInstance = instField.get(null);
@@ -51,7 +38,7 @@ public class WorldStreamerBooster {
                         }
                     }
 
-                    // 2. Scan all thread groups and ensure background workers do not preempt gameplay
+                    // Apply the same priority policy to other background workers.
                     ThreadGroup rootGroup = Thread.currentThread().getThreadGroup();
                     while (rootGroup.getParent() != null) {
                         rootGroup = rootGroup.getParent();
@@ -94,7 +81,6 @@ public class WorldStreamerBooster {
             Object wsInstance = instField.get(null);
             if (wsInstance == null) return false;
 
-            // 1. Upgrade decompressor to NativeInflater (Multiplayer SIMD AVX2 acceleration) only if native DLL is loaded
             if (PZONative.isLoaded()) {
                 Field decompField = wsClass.getDeclaredField("decompressor");
                 decompField.setAccessible(true);
@@ -104,7 +90,6 @@ public class WorldStreamerBooster {
                 }
             }
 
-            // 2. Upgrade readBuf to 256 KB
             Field readBufField = wsClass.getDeclaredField("readBuf");
             readBufField.setAccessible(true);
             byte[] curReadBuf = (byte[]) readBufField.get(wsInstance);
@@ -112,7 +97,6 @@ public class WorldStreamerBooster {
                 setField(wsInstance, readBufField, new byte[262144]);
             }
 
-            // 3. Pre-allocate inMemoryZip to 512 KB
             Field zipField = wsClass.getDeclaredField("inMemoryZip");
             zipField.setAccessible(true);
             ByteBuffer curZip = (ByteBuffer) zipField.get(wsInstance);

--- a/src/com/pzoptimizer/ZOcclusionCuller.java
+++ b/src/com/pzoptimizer/ZOcclusionCuller.java
@@ -3,18 +3,6 @@ package com.pzoptimizer;
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicLong;
 
-/**
- * PZO Subterranean Z-Level Occlusion Shield (Build 42 32-Level Vertical Culler).
- * 
- * In Build 42, the world supports up to 32 vertical levels (-16 to +16).
- * When the player is on the surface (Z >= 0) and not currently descending into a basement pit,
- * all subterranean tile geometry (Z = -1 .. -16) is 100% occluded by ground terrain and solid foundation.
- * 
- * ZOcclusionCuller drops underground tile render sweeps when on the surface:
- * - Eliminates thousands of redundant tile geometry iterations per frame.
- * - Only active in Unstable / Beta channel builds.
- * - Instantly engages full rendering as soon as the player enters Z < 0.
- */
 public final class ZOcclusionCuller {
 
     public static final AtomicLong subterraneanTilesCulled = new AtomicLong(0);
@@ -33,7 +21,6 @@ public final class ZOcclusionCuller {
 
         updatePlayerZ();
 
-        // If player is on surface (Z >= 0), subterranean levels (Z < 0) are occluded by ground terrain
         if (cachedPlayerZ >= 0) {
             subterraneanTilesCulled.addAndGet(64); // 8x8 tile layer equivalent
             return false;

--- a/src/com/pzoptimizer/ZombieMathVectorizer.java
+++ b/src/com/pzoptimizer/ZombieMathVectorizer.java
@@ -3,17 +3,11 @@ package com.pzoptimizer;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 
-/**
- * Project Zomboid Build 42 - SIMD-Inspired Vectorized Zombie Math Engine (Phase 3).
- * Accelerates distance calculations, line-of-sight raycasts, angle interpolation,
- * and batch spatial entity culling using 8-wide AVX2 instructions and FastMath lookup tables.
- */
 public class ZombieMathVectorizer {
     private static boolean active = false;
 
     public static void apply() {
         try {
-            // Warm the FastMath trigonometric tables into CPU L1/L2 cache
             for (int i = -180; i <= 180; i++) {
                 float rad = (float) Math.toRadians(i);
                 FastMath.sin(rad);
@@ -35,68 +29,41 @@ public class ZombieMathVectorizer {
         return PZONative.isLoaded() && PZONative.isAVX2Supported();
     }
 
-    /**
-     * Batch calculates Euclidean distances for up to N entities using 8-wide AVX2 SIMD.
-     */
     public static int batchDistances(FloatBuffer directCoords, int count, float ox, float oy, FloatBuffer directOutDist) {
         return PZONative.calculateDistancesAVX2(directCoords, count, ox, oy, directOutDist);
     }
 
-    /**
-     * Batch calculates squared distances for up to N entities using 8-wide AVX2 SIMD (no sqrt).
-     */
     public static int batchDistancesSq(FloatBuffer directCoords, int count, float ox, float oy, FloatBuffer directOutDistSq) {
         return PZONative.calculateDistancesSqAVX2(directCoords, count, ox, oy, directOutDistSq);
     }
 
-    /**
-     * Batch tests radial proximity for up to N entities using 8-wide AVX2 SIMD.
-     */
     public static int batchCullRadial(FloatBuffer directCoords, int count, float ox, float oy, float maxRadSq, ByteBuffer directOutMask) {
         return PZONative.cullRadialAVX2(directCoords, count, ox, oy, maxRadSq, directOutMask);
     }
 
-    /**
-     * Batch tests 2D AABB bounding box for up to N entities using 8-wide AVX2 SIMD.
-     */
     public static int batchCullAABB(FloatBuffer directCoords, int count, float minX, float minY, float maxX, float maxY, ByteBuffer directOutMask) {
         return PZONative.cullAABBAVX2(directCoords, count, minX, minY, maxX, maxY, directOutMask);
     }
 
-    /**
-     * Batch classifies multi-tier LOD for up to N entities using 8-wide AVX2 SIMD.
-     */
     public static int batchClassifyTiers(FloatBuffer directCoords, int count, float ox, float oy,
                                          float t0Sq, float t1Sq, float t2Sq, ByteBuffer directOutTiers) {
         return PZONative.classifyTiersAVX2(directCoords, count, ox, oy, t0Sq, t1Sq, t2Sq, directOutTiers);
     }
 
-    /**
-     * Fast squared Euclidean distance calculation without square root overhead.
-     */
     public static float distanceSq(float x1, float y1, float x2, float y2) {
         float dx = x2 - x1;
         float dy = y2 - y1;
         return dx * dx + dy * dy;
     }
 
-    /**
-     * Fast Manhattan distance for rapid spatial grid culling.
-     */
     public static float manhattanDistance(float x1, float y1, float x2, float y2) {
         return Math.abs(x2 - x1) + Math.abs(y2 - y1);
     }
 
-    /**
-     * Fast Euclidean distance using fast inverse square root approximation.
-     */
     public static float fastDistance(float x1, float y1, float x2, float y2) {
         return FastMath.distance(x1, y1, x2, y2);
     }
 
-    /**
-     * Fast direction angle between two entities using trigonometric lookup.
-     */
     public static float fastAngle(float x1, float y1, float x2, float y2) {
         return (float) Math.atan2(y2 - y1, x2 - x1);
     }

--- a/src/com/pzoptimizer/ZomboidConfigMigrator.java
+++ b/src/com/pzoptimizer/ZomboidConfigMigrator.java
@@ -9,18 +9,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Project Zomboid Build 42 - Configuration Migrator & Validator.
- * Automatically inspects and patches ProjectZomboid64.json (and Info.plist on macOS)
- * during in-game updates or early engine startup.
- *
- * Ensures backward compatibility when upgrading from older releases (such as 0.8.2) to 0.9.5+,
- * injecting required JVM 17/21+ arguments, the native JVMTI agent bridge (-agentlib:pzo_native64),
- * and B42 HotSpot performance tuning while strictly preserving custom user RAM allocations (-Xmx/-Xms)
- * and ZombieBuddy coexistence (-agentlib:zbNative).
- *
- * 100% pure Java with zero external dependencies.
- */
+/** Migrates launcher configuration while preserving custom heap sizes and agent entries. */
 public final class ZomboidConfigMigrator {
 
     public static final String TARGET_JSON_NAME = "ProjectZomboid64.json";
@@ -48,9 +37,6 @@ public final class ZomboidConfigMigrator {
         "-XX:+AlwaysPreTouch"
     };
 
-    /**
-     * Checks if the specified ProjectZomboid64.json requires migration to 0.9.5 standards.
-     */
     public static boolean isMigrationNeeded(File jsonFile) {
         if (jsonFile == null || !jsonFile.exists() || jsonFile.length() == 0) {
             return false;
@@ -66,13 +52,11 @@ public final class ZomboidConfigMigrator {
             @SuppressWarnings("unchecked")
             Map<String, Object> map = (Map<String, Object>) parsed;
 
-            // Check mainClass
             Object mainClass = map.get("mainClass");
             if (mainClass == null || !TARGET_MAIN_CLASS.equals(mainClass.toString().trim())) {
                 return true;
             }
 
-            // Check classpath
             Object cpObj = map.get("classpath");
             if (!(cpObj instanceof List)) {
                 return true;
@@ -91,7 +75,6 @@ public final class ZomboidConfigMigrator {
                 return true;
             }
 
-            // Check vmArgs
             Object vmObj = map.get("vmArgs");
             if (!(vmObj instanceof List)) {
                 return true;
@@ -102,14 +85,12 @@ public final class ZomboidConfigMigrator {
                 if (item != null) vmStrings.add(item.toString().trim());
             }
 
-            // Check for critical missing flags
             for (String req : REQUIRED_VM_ARGS) {
                 if (!vmStrings.contains(req)) {
                     return true;
                 }
             }
 
-            // Check for library path
             boolean hasLibPath = false;
             String os = System.getProperty("os.name", "").toLowerCase();
             for (String arg : vmStrings) {
@@ -124,7 +105,6 @@ public final class ZomboidConfigMigrator {
                 return true;
             }
 
-            // Check if undesirable headless flag is still lingering
             for (String arg : vmStrings) {
                 if (arg.startsWith("-Djava.awt.headless")) {
                     return true;
@@ -138,9 +118,6 @@ public final class ZomboidConfigMigrator {
         }
     }
 
-    /**
-     * Migrates the provided JSON string into the updated 0.9.5 configuration format.
-     */
     public static String migrateJsonContent(String originalJson, File gameDir) {
         Object parsed = JsonMini.parse(originalJson);
         if (!(parsed instanceof Map)) {
@@ -150,10 +127,8 @@ public final class ZomboidConfigMigrator {
         @SuppressWarnings("unchecked")
         Map<String, Object> root = (Map<String, Object>) parsed;
 
-        // 1. Set optimized entrypoint
         root.put("mainClass", TARGET_MAIN_CLASS);
 
-        // 2. Classpath normalization (preserve custom JARs, ensure PZOptimEngine.jar and . are present)
         List<String> cpList = new ArrayList<>();
         Object cpObj = root.get("classpath");
         if (cpObj instanceof List) {
@@ -180,7 +155,6 @@ public final class ZomboidConfigMigrator {
         }
         root.put("classpath", cpList);
 
-        // 3. vmArgs normalization & migration
         List<String> rawArgs = new ArrayList<>();
         Object vmObj = root.get("vmArgs");
         if (vmObj instanceof List) {
@@ -189,7 +163,6 @@ public final class ZomboidConfigMigrator {
             }
         }
 
-        // Detect ZombieBuddy active presence
         boolean zbActive = false;
         for (String arg : rawArgs) {
             if (arg.contains("zbNative") || arg.contains("ZombieBuddy")) {
@@ -207,7 +180,6 @@ public final class ZomboidConfigMigrator {
             }
         }
 
-        // Clean undesirable or superseded arguments
         List<String> userCleanArgs = new ArrayList<>();
         for (String arg : rawArgs) {
             if (arg.startsWith("-Djava.awt.headless")) continue; // PZO requires GUI/AWT
@@ -223,18 +195,15 @@ public final class ZomboidConfigMigrator {
 
         List<String> targetArgs = new ArrayList<>();
 
-        // 3a. Native agent bridges first
         targetArgs.add(TARGET_AGENTLIB);
         if (zbActive) {
             targetArgs.add("-agentlib:zbNative");
             PZOLogger.info("[ZomboidConfigMigrator] Preserved ZombieBuddy bridge (-agentlib:zbNative)");
         }
 
-        // 3b. JVM 17/21+ export & native access parameters
         targetArgs.add("--enable-native-access=ALL-UNNAMED");
         targetArgs.add("--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED");
 
-        // 3c. Platform-specific native library search paths
         if (isWin) {
             targetArgs.add("-Djava.library.path=win64/;.;natives/");
         } else if (isLinux) {
@@ -243,7 +212,6 @@ public final class ZomboidConfigMigrator {
             targetArgs.add("-Djava.library.path=.:ProjectZomboid.app/Contents/MacOS/:ProjectZomboid.app/Contents/Java/");
         }
 
-        // 3d. User memory allocations (-Xms, -Xmx) and Steam args preserved
         boolean hasXms = false;
         boolean hasXmx = false;
         for (String arg : userCleanArgs) {
@@ -254,11 +222,9 @@ public final class ZomboidConfigMigrator {
             }
         }
 
-        // Default memory fallback if user config lacked heap sizing
         if (!hasXms) targetArgs.add(3, "-Xms2048m");
         if (!hasXmx) targetArgs.add(4, "-Xmx4096m");
 
-        // 3e. Inject all 0.9.5 performance flags if missing
         for (String pf : REQUIRED_VM_ARGS) {
             if (!targetArgs.contains(pf)) {
                 targetArgs.add(pf);
@@ -270,10 +236,7 @@ public final class ZomboidConfigMigrator {
         return JsonMini.format(root);
     }
 
-    /**
-     * Migrates the specified JSON file in place, saving a .bak copy of the original.
-     * Safe to call while the game is running (file handle is not locked by JVM/launcher).
-     */
+    /** Migrates the JSON file in place after saving a .bak copy. */
     public static boolean migrateFileInPlace(File jsonFile) {
         if (jsonFile == null || !jsonFile.exists()) return false;
         try {
@@ -297,11 +260,7 @@ public final class ZomboidConfigMigrator {
         }
     }
 
-    /**
-     * Staging helper for auto-updaters (UpdateDialog):
-     * Writes the migrated configuration to ProjectZomboid64.json.new so that the
-     * updater script can atomically replace it when the game process terminates.
-     */
+    /** Stages ProjectZomboid64.json.new for the updater to replace after the game exits. */
     public static boolean prepareStagedUpdate(File gameDir) {
         if (gameDir == null) return false;
         try {
@@ -337,11 +296,6 @@ public final class ZomboidConfigMigrator {
         }
     }
 
-    /**
-     * Startup verification:
-     * Called during early PZOEntrypoint boot. Inspects ProjectZomboid64.json in the
-     * working directory and immediately repairs it if it lacks required 0.9.5 flags.
-     */
     public static void checkAndMigrateCurrentInstallation(File gameDir) {
         try {
             if (gameDir == null) gameDir = new File(".").getAbsoluteFile();
@@ -358,9 +312,6 @@ public final class ZomboidConfigMigrator {
         }
     }
 
-    /**
-     * Lightweight recursive JSON parser and serializer with zero external dependencies.
-     */
     public static class JsonMini {
         public static Object parse(String json) {
             if (json == null) return null;

--- a/src/com/pzoptimizer/multicore/MultiCoreAnimationEngine.java
+++ b/src/com/pzoptimizer/multicore/MultiCoreAnimationEngine.java
@@ -15,28 +15,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
-/**
- * PZO Multi-Core Skeletal Animation Engine (Pillar 3).
- * 
- * Solves Build 42 skeletal skinning CPU bottlenecks without static scratch race conditions:
- * 
- * 1. Off-screen bone matrix multiplication elimination:
- *    Hooks MultiCoreHordeGovernor AABB culling mask to skip 100% of CPU skeletal matrix computations
- *    for non-visible entities (saving 64 bone transforms per entity per frame).
- * 2. Distant entity (Tier 2, 32-50 tiles away) LOD downsampling:
- *    Reduces animation evaluation from 60 FPS to 15 FPS (4x computation reduction) with cached matrices.
- * 3. Multi-threaded ModelInstance.UpdateDir() pre-staging across CPU cores, protected by ModelInstance.lock.
- * 4. Thread-local transform scratchpads for thread safety without static variable collision.
- */
 public final class MultiCoreAnimationEngine {
 
     private static final AtomicBoolean initialized = new AtomicBoolean(false);
 
-    // Telemetry metrics
     public static final AtomicLong totalParallelAnimationUpdates = new AtomicLong(0);
     public static final AtomicLong totalBoneTransformsBypassed = new AtomicLong(0);
 
-    // Thread-local math scratchpads ensuring zero collision with AnimationPlayer$L_updateBoneAnimationTransform
+    // Per-thread scratch storage avoids sharing transform temporaries.
     public static final ThreadLocal<Matrix4f> TL_MATRIX = ThreadLocal.withInitial(Matrix4f::new);
     public static final ThreadLocal<Quaternion> TL_QUAT = ThreadLocal.withInitial(Quaternion::new);
     public static final ThreadLocal<Vector3f> TL_VEC3 = ThreadLocal.withInitial(Vector3f::new);
@@ -48,17 +34,12 @@ public final class MultiCoreAnimationEngine {
         PZOLogger.success("[MultiCoreAnimationEngine] Armed: Thread-Safe Multi-Core Skeletal Animation Pipeline");
     }
 
-    /**
-     * Determines whether full skeletal skinning matrix transformation should occur for a given entity.
-     */
     public static boolean shouldSkinModel(float screenX, float screenY, int entityIndex) {
-        // 1. Check if HordeGovernor marked this entity as outside camera frustum
         if (entityIndex >= 0 && MultiCoreHordeGovernor.isEntityCulled(entityIndex)) {
             totalBoneTransformsBypassed.addAndGet(64);
             return false;
         }
 
-        // 2. Fall back to screen viewport bounds check
         if (!ModelSkinningGovernor.shouldSkinModel(screenX, screenY)) {
             totalBoneTransformsBypassed.addAndGet(64);
             return false;
@@ -67,30 +48,23 @@ public final class MultiCoreAnimationEngine {
         return true;
     }
 
-    /**
-     * Determines whether bone transforms should be evaluated this frame for distant entities (LOD downsampling).
-     */
     public static boolean shouldUpdateLOD(int entityIndex, long frameCounter) {
         if (entityIndex < 0) return true;
 
         byte tier = MultiCoreHordeGovernor.getEntityTier(entityIndex);
         if (tier >= 2) {
-            // Tier 2 (32-50 tiles): Evaluate only every 4th frame (15 FPS), reusing bone matrices
+            // Evaluate tier 2 every fourth frame, reusing bone matrices in between.
             return (frameCounter & 3) == 0;
         }
 
         return true;
     }
 
-    /**
-     * Parallelizes ModelSlot direction and track pre-staging across worker pool.
-     */
     public static void stageParallelModelSlots(List<ModelManager.ModelSlot> slots, float delta) {
         if (slots == null || slots.isEmpty() || PZOMultiCoreEngine.getExecutor() == null) return;
 
         int size = slots.size();
         if (size <= 16) {
-            // Small count: process sequentially
             for (int i = 0; i < size; i++) {
                 updateSlotDirect(slots.get(i), delta);
             }
@@ -132,12 +106,6 @@ public final class MultiCoreAnimationEngine {
 
     private static final AtomicLong frameCounter = new AtomicLong(0);
 
-    /**
-     * Applies dynamic multi-threaded skeletal bone update culling and LOD across the active horde.
-     * Off-screen zombies bypass 100% of bone matrix calculations (saving 64 matrix ops per entity per frame).
-     * Distant zombies (Tier 2, 32-50 tiles) downsample bone updates to alternate frames.
-     * Evaluates in parallel across dedicated P-Core worker threads.
-     */
     public static void applyHordeAnimationGovernor(List<?> zombies, int count, byte[] cullMask, byte[] tiers) {
         if (zombies == null || count <= 0 || cullMask == null) return;
 
@@ -175,28 +143,23 @@ public final class MultiCoreAnimationEngine {
 
             boolean culled = (i < cullMask.length && cullMask[i] == 0);
             if (culled) {
-                // Off-screen: completely bypass bone transform matrix computations
                 animPlayer.updateBones = false;
                 bypassed += 64;
             } else {
                 byte tier = (tiers != null && i < tiers.length) ? tiers[i] : 0;
                 if (tier >= 3) {
-                    // Ultra-Distant entity (40+ tiles away): evaluate 1-in-4 frames (15 FPS keyframing)
                     boolean updateThisFrame = ((frame + i) & 3) == 0;
                     animPlayer.updateBones = updateThisFrame;
                     if (!updateThisFrame) bypassed += 64;
                 } else if (tier == 2) {
-                    // Far entity (25-40 tiles away): evaluate 1-in-3 frames (20 FPS keyframing)
                     boolean updateThisFrame = ((frame + i) % 3) == 0;
                     animPlayer.updateBones = updateThisFrame;
                     if (!updateThisFrame) bypassed += 64;
                 } else if (tier == 1) {
-                    // Mid entity (12-25 tiles away): evaluate alternate frames (30 FPS keyframing)
                     boolean updateThisFrame = ((frame + i) & 1) == 0;
                     animPlayer.updateBones = updateThisFrame;
                     if (!updateThisFrame) bypassed += 64;
                 } else {
-                    // Close / combat entity (0-12 tiles): full 60 FPS animation fidelity
                     animPlayer.updateBones = true;
                 }
             }

--- a/src/com/pzoptimizer/multicore/MultiCoreChunkStreamer.java
+++ b/src/com/pzoptimizer/multicore/MultiCoreChunkStreamer.java
@@ -18,45 +18,29 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-/**
- * PZO Multi-Core Chunk Streamer (Pillar 1).
- * 
- * Re-architects Project Zomboid Build 42 chunk streaming from a single background thread
- * with artificial 140ms sleeps into a true multi-core parallel streaming engine:
- * 
- * 1. Dedicated physical P-core pinned worker pool (4 to 12 workers).
- * 2. Per-thread direct off-heap 1MB NIO buffer ring, bypassing the single shared static IsoChunk.sliceBufferLoad.
- * 3. Concurrent multi-threaded chunk disk I/O and stream decoding via IsoChunk.SafeRead per-chunk locks.
- * 4. Active sleep bypass for WorldStreamer thread loop, eliminating frame stalls and void pop-in at high vehicle speeds.
- * 5. Direct feed into IsoChunk.loadGridSquare and ChunkIngestionPacer.
- */
 public final class MultiCoreChunkStreamer {
 
     private static final AtomicBoolean initialized = new AtomicBoolean(false);
     private static volatile boolean running = false;
 
-    // Worker pool & dispatcher
     private static ExecutorService workerPool;
     private static Thread dispatcherThread;
     private static int workerCount = 4;
 
-    // Thread-local heap NIO chunk buffers (1 MB per worker thread = zero GC overhead + supports .array() for CRC32)
+    // Heap buffers support the array() access used by CRC32.
     private static final ThreadLocal<ByteBuffer> DIRECT_CHUNK_BUFFER = ThreadLocal.withInitial(() -> {
         return ByteBuffer.allocate(1048576); // 1,048,576 bytes = 1 MB heap buffer
     });
 
-    // Thread-safe in-flight chunk tracking to eliminate duplicate parallel loading
     private static final Set<Long> IN_FLIGHT_CHUNKS = ConcurrentHashMap.newKeySet();
 
     // Guard lock for brief static state parsing in IsoChunk.LoadFromDiskOrBufferInternal
     private static final Object CHUNK_PARSE_LOCK = new Object();
 
-    // Telemetry metrics
     public static final AtomicLong totalChunksStreamedParallel = new AtomicLong(0);
     public static final AtomicLong totalStreamTimeSavedMs = new AtomicLong(0);
     public static final AtomicInteger activeChunkWorkers = new AtomicInteger(0);
 
-    // Reflection handles into WorldStreamer internals
     private static Field jobListField = null;
     private static Field jobQueueField = null;
     private static Field worldStreamerThreadField = null;
@@ -83,7 +67,6 @@ public final class MultiCoreChunkStreamer {
     public static synchronized void initialize() {
         if (initialized.get()) return;
 
-        // Determine optimal worker count based on physical P-cores
         int pCores = PZONative.isLoaded() ? PZONative.getPerformanceCores() : Runtime.getRuntime().availableProcessors();
         workerCount = Math.max(2, Math.min(pCores, 12));
 
@@ -148,12 +131,7 @@ public final class MultiCoreChunkStreamer {
 
     private static volatile boolean queueHooked = false;
 
-    /**
-     * Specialized queue installed into WorldStreamer.jobQueue via Unsafe.
-     * Intercepts incoming chunk load requests, triggers asynchronous
-     * parallel disk pre-read and AVX2 decompression across P-Core workers, and passes
-     * chunks to WorldStreamer with zero monitor lock contention.
-     */
+    /** Routes WorldStreamer.jobQueue requests to the worker queue. */
     public static class PZOChunkStreamQueue extends ConcurrentLinkedQueue<IsoChunk> {
         @Override
         public boolean offer(IsoChunk chunk) {
@@ -197,7 +175,6 @@ public final class MultiCoreChunkStreamer {
     }
 
     private static void dispatcherLoop() {
-        // Bind dispatcher to P-cores
         PZONative.bindCallingThreadToPCores();
 
         while (running) {
@@ -228,7 +205,6 @@ public final class MultiCoreChunkStreamer {
 
         long chunkKey = (((long) chunk.wx) << 32) | (((long) chunk.wy) & 0xFFFFFFFFL);
         if (!IN_FLIGHT_CHUNKS.add(chunkKey)) {
-            // Chunk coordinate is ALREADY in-flight on another worker; deduplicate
             return;
         }
 
@@ -238,18 +214,16 @@ public final class MultiCoreChunkStreamer {
             try {
                 long startTime = System.nanoTime();
                 try {
-                    // Ensure worker thread has P-Core affinity
                     PZONative.bindCallingThreadToPCores();
 
                     processChunkParallel(chunk);
 
                     long durationMs = (System.nanoTime() - startTime) / 1_000_000L;
                     totalChunksStreamedParallel.incrementAndGet();
-                    totalStreamTimeSavedMs.addAndGet(Math.max(1, 140L - durationMs)); // Vanilla wastes 140ms sleep
+                    totalStreamTimeSavedMs.addAndGet(Math.max(1, 140L - durationMs)); // Estimated against a fixed 140 ms baseline; not a measured saving.
                 } catch (Throwable t) {
                     PZOLogger.warn("[MultiCoreChunkStreamer] Fallback recovery for chunk (" + chunk.wx + "," + chunk.wy + "): " + t.getMessage());
-                    // Fallback: Safely parse synchronously under parse lock without dumping into WorldStreamer.jobQueue
-                    // (Dumping into WorldStreamer risks thread collisions because WorldStreamer does not acquire CHUNK_PARSE_LOCK).
+                    // Retry under the parse lock; requeueing to WorldStreamer would bypass this lock.
                     try {
                         synchronized (getParseLock()) {
                             resetSanityCheck();
@@ -287,16 +261,14 @@ public final class MultiCoreChunkStreamer {
     public static void processChunkParallel(IsoChunk chunk) {
         if (chunk == null || chunk.loaded) return;
 
-        // Note: Save/load mutual exclusion is natively guaranteed by IsoChunk.acquireLock(wx, wy),
-        // and background saves are safely handled by WorldStreamer. Calling ChunkSaveWorker.Update here
-        // caused MainThread freezes and non-thread-safe SaveBufferMap race conditions.
+        // IsoChunk.acquireLock(wx, wy) coordinates save/load access.
+        // Leave saves to WorldStreamer: calling ChunkSaveWorker.Update here caused freezes
+        // and races in SaveBufferMap.
 
         ByteBuffer workerBuf = DIRECT_CHUNK_BUFFER.get();
         workerBuf.clear();
 
         try {
-            // 1. Parallel Disk I/O & Decompression via IsoChunk.SafeRead (uses fine-grained per-chunk locks)
-            // Checks Predictive Trajectory Preloaded Cache first: 0ms in-memory cache hit!
             ByteBuffer loadedData = null;
             byte[] preloaded = com.pzoptimizer.PredictiveChunkStreamer.pollPreloadedChunk(chunk.wx, chunk.wy);
             if (preloaded != null) {
@@ -320,23 +292,18 @@ public final class MultiCoreChunkStreamer {
                 }
             }
 
-            // 2. High-speed parse & link step:
-            // Guarded with getParseLock() (the IsoChunk.sanityCheck singleton monitor lock).
-            // Synchronizing on sanityCheckInstance guarantees mutual exclusion with both other workers
-            // AND any vanilla WorldStreamer operations (since SanityCheck.beginLoad/endLoad synchronize on sanityCheck).
+            // Use the IsoChunk.sanityCheck monitor shared with vanilla parsing.
             synchronized (getParseLock()) {
                 resetSanityCheck();
                 try {
                     chunk.LoadChunk(chunk.wx, chunk.wy, loadedData);
 
-                    // Vehicles DB: Always load vehicle instances from vehicles.db for all chunks
                     if (VehiclesDB2.instance != null) {
                         try {
                             VehiclesDB2.instance.loadChunk(chunk);
                         } catch (Throwable ignored) {}
                     }
 
-                    // 3. Handle conversion, soft reset, or link into loadGridSquare
                     if (chunk.jobType == IsoChunk.JobType.Convert || chunk.jobType == IsoChunk.JobType.SoftReset) {
                         chunk.doLoadGridsquare();
                         chunk.loaded = true;
@@ -354,7 +321,6 @@ public final class MultiCoreChunkStreamer {
             }
 
         } catch (Throwable t) {
-            // Re-throw to trigger fallback in caller
             throw new RuntimeException(t);
         }
     }

--- a/src/com/pzoptimizer/multicore/MultiCoreHordeGovernor.java
+++ b/src/com/pzoptimizer/multicore/MultiCoreHordeGovernor.java
@@ -16,15 +16,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-/**
- * PZO Multi-Core Horde Governor (Pillar 2).
- * 
- * Accelerates large horde spatial proximity checks, frustum culling, and multi-tier
- * LOD classification by distributing 256-entity partitions across all available physical CPU cores
- * using 8-wide AVX2 SIMD vectorization.
- * 
- * Achieves sub-0.02ms sweep times across 3,000+ active zombies with ZERO heap allocation.
- */
 public final class MultiCoreHordeGovernor {
 
     private static final AtomicBoolean initialized = new AtomicBoolean(false);
@@ -34,14 +25,13 @@ public final class MultiCoreHordeGovernor {
     public static final int PARTITION_SIZE = 256;
     private static final int MAX_ENTITIES = SpatialBufferPool.MAX_ENTITIES;
 
-    // Telemetry & state snapshots
     public static final AtomicInteger lastTrackedZombieCount = new AtomicInteger(0);
     public static final AtomicInteger lastCulledOffscreenCount = new AtomicInteger(0);
     public static final AtomicInteger lastHibernatingCount = new AtomicInteger(0);
     public static final AtomicLong totalParallelSweeps = new AtomicLong(0);
     public static final AtomicLong totalSweepTimeNanos = new AtomicLong(0);
 
-    // Snapshot arrays for atomic lock-free reads by other game subsystems
+    // Shared result snapshots.
     private static final byte[] SNAPSHOT_TIERS = new byte[MAX_ENTITIES];
     private static final byte[] SNAPSHOT_MASK = new byte[MAX_ENTITIES];
     private static final float[] SNAPSHOT_DISTANCES = new float[MAX_ENTITIES];
@@ -50,7 +40,6 @@ public final class MultiCoreHordeGovernor {
     public static final AtomicInteger lastVisibleCount = new AtomicInteger(0);
     private static volatile int snapshotCount = 0;
 
-    // Thresholds
     public static final float TIER_CLOSE_SQ = 16.0f * 16.0f;     // 256 tiles^2  (LOD 0)
     public static final float TIER_MEDIUM_SQ = 32.0f * 32.0f;   // 1024 tiles^2 (LOD 1)
     public static final float TIER_FAR_SQ = 50.0f * 50.0f;      // 2500 tiles^2 (LOD 2)
@@ -62,7 +51,6 @@ public final class MultiCoreHordeGovernor {
     public static final float SEPARATION_RADIUS = 1.25f;         // 1.25 tiles crowd repulsion radius
     public static final float MAX_REPULSION_FORCE = 0.08f;       // Steering nudge clamp
 
-    // Cached Reflection Handles
     private static Field fieldX = null;
     private static Field fieldY = null;
     private static Method methodGetX = null;
@@ -235,7 +223,6 @@ public final class MultiCoreHordeGovernor {
             ByteBuffer fovBuf = SpatialBufferPool.getFovMaskBuffer();
             FloatBuffer repulsionBuf = SpatialBufferPool.getRepulsionBuffer();
 
-            // Populate coordinates and headings sequentially (fast memory write)
             coordBuf.rewind();
             headingBuf.rewind();
             for (int i = 0; i < count; i++) {
@@ -255,7 +242,6 @@ public final class MultiCoreHordeGovernor {
 
             long sweepStart = System.nanoTime();
 
-            // Parallel AVX2 Vectorized Computation across all CPU cores
             float minX = px - CAMERA_HALF_SPAN;
             float minY = py - CAMERA_HALF_SPAN;
             float maxX = px + CAMERA_HALF_SPAN;
@@ -263,13 +249,11 @@ public final class MultiCoreHordeGovernor {
 
             int numPartitions = (count + PARTITION_SIZE - 1) / PARTITION_SIZE;
             if (numPartitions <= 1 || PZOMultiCoreEngine.getExecutor() == null) {
-                // Single-partition scalar/AVX2
                 PZONative.calculateDistancesAVX2(coordBuf, count, px, py, distBuf);
                 PZONative.classifyTiersAVX2(coordBuf, count, px, py, TIER_CLOSE_SQ, TIER_MEDIUM_SQ, TIER_FAR_SQ, tiersBuf);
                 PZONative.cullAABBAVX2(coordBuf, count, minX, minY, maxX, maxY, maskBuf);
                 PZONative.calculateFovAVX2(coordBuf, headingBuf, count, px, py, FOV_DIST_SQ, COS_HALF_FOV, CLOSE_AWARE_SQ, fovBuf);
             } else {
-                // Multi-core parallel SIMD execution
                 List<CompletableFuture<Void>> futures = new ArrayList<>(numPartitions);
                 for (int p = 0; p < numPartitions; p++) {
                     final int startIdx = p * PARTITION_SIZE;
@@ -311,14 +295,13 @@ public final class MultiCoreHordeGovernor {
                 CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
             }
 
-            // SIMD Crowd Flocking & Separation Vector Accelerator across nearby entities
             if (count >= 2) {
                 PZONative.calculateRepulsionAVX2(coordBuf, count, SEPARATION_RADIUS, MAX_REPULSION_FORCE, repulsionBuf);
                 repulsionBuf.rewind();
                 repulsionBuf.get(SNAPSHOT_REPULSION, 0, count * 2);
             }
 
-            // Transfer directly into snapshot arrays for instant thread-safe lookups
+            // Copy results into the shared snapshot arrays.
             distBuf.rewind();
             distBuf.get(SNAPSHOT_DISTANCES, 0, count);
 
@@ -347,14 +330,13 @@ public final class MultiCoreHordeGovernor {
             lastHibernatingCount.set(hibernating);
             lastVisibleCount.set(visible);
 
-            // Synchronize with HordeSpatialCuller for zero-overhead legacy lookups
+            // Update the legacy HordeSpatialCuller snapshot.
             com.pzoptimizer.HordeSpatialCuller.syncFromMultiCore(count, culled, hibernating, SNAPSHOT_DISTANCES, SNAPSHOT_TIERS, SNAPSHOT_MASK);
 
             long sweepDuration = System.nanoTime() - sweepStart;
             totalParallelSweeps.incrementAndGet();
             totalSweepTimeNanos.addAndGet(sweepDuration);
 
-            // Multi-Core Skeletal Bone Skinning Governor: bypass off-screen bone matrix evaluations
             MultiCoreAnimationEngine.applyHordeAnimationGovernor(zombies, count, SNAPSHOT_MASK, SNAPSHOT_TIERS);
 
         } catch (Throwable ignored) {}

--- a/src/com/pzoptimizer/multicore/MultiCoreIslandScheduler.java
+++ b/src/com/pzoptimizer/multicore/MultiCoreIslandScheduler.java
@@ -23,23 +23,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-/**
- * PZO Island-Based Spatial Partitioning Simulation Scheduler (Pillar 4).
- * 
- * Re-architects MovingObjectUpdateScheduler from single-threaded sequential simulation
- * into non-interfering 32x32 tile spatial islands:
- * 
- * 1. Dual-Phase Checkerboard Partitioning:
- *    - Red Islands ((ix + iy) % 2 == 0) are separated from each other by at least 32 tiles.
- *    - Black Islands ((ix + iy) % 2 == 1) are separated from each other by at least 32 tiles.
- *    - Zero interaction overlap: Entities in different Red islands can NEVER touch or modify the same tiles!
- * 2. Parallel Multi-Core Execution:
- *    - Phase A: All Red islands execute preupdate(), frameStep(), update(), postupdate() across all CPU cores in parallel.
- *    - Phase B: All Black islands execute preupdate(), frameStep(), update(), postupdate() across all CPU cores in parallel.
- * 3. Boundary & Player Protection:
- *    - Entities within 2 tiles of an island boundary or within 12 tiles of players are reserved for the main simulation thread.
- * 4. Zero allocation, lock-free spatial simulation scaling across all performance cores.
- */
 public final class MultiCoreIslandScheduler {
 
     private static final AtomicBoolean initialized = new AtomicBoolean(false);
@@ -49,11 +32,9 @@ public final class MultiCoreIslandScheduler {
     public static final float SAFETY_MARGIN = 2.0f; // 2 tiles boundary buffer
     public static final float PLAYER_SAFETY_RADIUS_SQ = 12.0f * 12.0f; // 144 tiles^2
 
-    // Telemetry metrics
     public static final AtomicLong totalParallelUpdates = new AtomicLong(0);
     public static final AtomicInteger lastSimulatedIslands = new AtomicInteger(0);
 
-    // Spatial island partitions
     public static class IslandBucket {
         public final int ix;
         public final int iy;
@@ -68,11 +49,8 @@ public final class MultiCoreIslandScheduler {
     public static synchronized void initialize() {
         if (initialized.get()) return;
 
-        // NOTE: In Build 42, MovingObjectUpdateScheduler manages IsoGameCharacter.updateAlpha()
-        // and non-thread-safe IsoGridSquare.movingObjects lists. Parallelizing simulation across
-        // background worker threads causes alpha calculation skips (invisible zombies) and race
-        // conditions on square transfer. We preserve main-thread simulation for 100% visual fidelity
-        // and collision integrity.
+        // Keep simulation on the main thread: updateAlpha() and movingObjects mutations
+        // caused visibility failures and square-transfer races on worker threads.
         initialized.set(true);
         active = false;
         PZOLogger.info("[MultiCoreIslandScheduler] Preserving main-thread simulation for 100% zombie visibility & collision safety");
@@ -136,15 +114,10 @@ public final class MultiCoreIslandScheduler {
         }
     }
 
-    /**
-     * Enhanced List implementation that intercepts MovingObjectUpdateSchedulerUpdateBucket
-     * and executes Red and Black spatial islands in parallel across CPU cores.
-     */
     public static class IslandAwareBucketList extends ArrayList<IsoMovingObject> {
         private final UpdateSchedulerSimulationLevel simulationLevel;
         private final int frameMod;
 
-        // Partitioned Island Storage
         private final Map<Long, IslandBucket> redIslands = new HashMap<>();
         private final Map<Long, IslandBucket> blackIslands = new HashMap<>();
         private final List<IsoMovingObject> boundaryAndPlayerObjects = new ArrayList<>(64);
@@ -162,17 +135,15 @@ public final class MultiCoreIslandScheduler {
         public boolean add(IsoMovingObject obj) {
             if (obj == null) return false;
 
-            // 0. Non-thread-safe entities that execute Lua (Vehicles, Players) must ALWAYS run on main simulation thread
+            // Vehicles and players can execute Lua and must stay on the main simulation thread.
             if (obj instanceof BaseVehicle || obj instanceof IsoPlayer) {
                 boundaryAndPlayerObjects.add(obj);
                 return super.add(obj);
             }
 
-            // Classify into island or boundary/player bucket
             float x = obj.getX();
             float y = obj.getY();
 
-            // 1. Check player safety radius
             IsoPlayer player = IsoPlayer.getInstance();
             if (player != null) {
                 float dx = x - player.getX();
@@ -183,7 +154,6 @@ public final class MultiCoreIslandScheduler {
                 }
             }
 
-            // 2. Check island boundary safety margin
             int ix = (int) Math.floor(x / ISLAND_SIZE);
             int iy = (int) Math.floor(y / ISLAND_SIZE);
 
@@ -196,7 +166,6 @@ public final class MultiCoreIslandScheduler {
                 return super.add(obj);
             }
 
-            // 3. Classify into Red (Phase 0) or Black (Phase 1)
             long key = FastChunkKey.pack(ix, iy);
             int phase = (ix + iy) & 1;
 
@@ -215,7 +184,7 @@ public final class MultiCoreIslandScheduler {
             if (!parallelSweepExecuted && (!redIslands.isEmpty() || !blackIslands.isEmpty())) {
                 executeParallelSimulation();
                 parallelSweepExecuted = true;
-                // Return boundary objects count so the vanilla caller executes only the boundary entities!
+                // Expose only boundary entities to the vanilla caller.
                 return boundaryAndPlayerObjects.size();
             } else if (parallelSweepExecuted && !parallelPostUpdateExecuted && (!redIslands.isEmpty() || !blackIslands.isEmpty())) {
                 executeParallelPostUpdate();
@@ -250,7 +219,6 @@ public final class MultiCoreIslandScheduler {
             int totalSimulated = 0;
             lastSimulatedIslands.set(redIslands.size() + blackIslands.size());
 
-            // Phase A: Red Islands simulated in parallel across CPU cores
             if (!redIslands.isEmpty()) {
                 List<CompletableFuture<Void>> redFutures = new ArrayList<>(redIslands.size());
                 for (IslandBucket island : redIslands.values()) {
@@ -263,7 +231,6 @@ public final class MultiCoreIslandScheduler {
                 CompletableFuture.allOf(redFutures.toArray(new CompletableFuture[0])).join();
             }
 
-            // Phase B: Black Islands simulated in parallel across CPU cores
             if (!blackIslands.isEmpty()) {
                 List<CompletableFuture<Void>> blackFutures = new ArrayList<>(blackIslands.size());
                 for (IslandBucket island : blackIslands.values()) {
@@ -280,7 +247,6 @@ public final class MultiCoreIslandScheduler {
         }
 
         private void executeParallelPostUpdate() {
-            // Phase A: Red Islands postupdate in parallel
             if (!redIslands.isEmpty()) {
                 List<CompletableFuture<Void>> redFutures = new ArrayList<>(redIslands.size());
                 for (IslandBucket island : redIslands.values()) {
@@ -292,7 +258,6 @@ public final class MultiCoreIslandScheduler {
                 CompletableFuture.allOf(redFutures.toArray(new CompletableFuture[0])).join();
             }
 
-            // Phase B: Black Islands postupdate in parallel
             if (!blackIslands.isEmpty()) {
                 List<CompletableFuture<Void>> blackFutures = new ArrayList<>(blackIslands.size());
                 for (IslandBucket island : blackIslands.values()) {

--- a/src/com/pzoptimizer/multicore/PZOMultiCoreEngine.java
+++ b/src/com/pzoptimizer/multicore/PZOMultiCoreEngine.java
@@ -8,18 +8,6 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-/**
- * PZO Master Multi-Core Engine Coordinator.
- * 
- * Orchestrates all 4 architectural multi-core scaling pillars:
- * 1. MultiCoreChunkStreamer: Parallel multi-threaded chunk decompression & stream decoding pool.
- * 2. MultiCoreHordeGovernor: Parallel AVX2 SIMD horde spatial culling, frustum/AABB culling, and LOD classification.
- * 3. MultiCoreAnimationEngine: Thread-safe multi-core skeletal animation and bone matrix transform pipeline.
- * 4. MultiCoreIslandScheduler: Island-based spatial grid partitioning (32x32 tiles / dual-phase checkerboard).
- * 
- * Manages dedicated physical P-core pinned worker pool and feeds real-time telemetry into
- * PZOEngineBridge and EnhancedRenderTelemetry.
- */
 public final class PZOMultiCoreEngine {
 
     private static final AtomicBoolean initialized = new AtomicBoolean(false);
@@ -31,7 +19,6 @@ public final class PZOMultiCoreEngine {
     public static synchronized void initialize() {
         if (initialized.get()) return;
 
-        // 1. Hardware topology detection & worker pool configuration
         int pCores = PZONative.isLoaded() ? PZONative.getPerformanceCores() : Runtime.getRuntime().availableProcessors();
         workerCount = Math.max(2, Math.min(pCores, 16));
 
@@ -46,7 +33,6 @@ public final class PZOMultiCoreEngine {
             }
         });
 
-        // 2. Initialize all 4 core pillars
         MultiCoreChunkStreamer.initialize();
         MultiCoreHordeGovernor.initialize();
         MultiCoreAnimationEngine.initialize();

--- a/src/com/pzoptimizer/server/LinuxSteamServerSanitizer.java
+++ b/src/com/pzoptimizer/server/LinuxSteamServerSanitizer.java
@@ -6,12 +6,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 
-/**
- * Linux Dedicated Server Steam Native Library Sanitizer.
- * Automatically resolves SteamAPI_Init() failures on Indifferent Broccoli, Pterodactyl,
- * Docker, and Linux game server panels by pre-loading steamclient.so and ensuring
- * ~/.steam/sdk64/steamclient.so is populated.
- */
 public class LinuxSteamServerSanitizer {
 
     public static void sanitize() {
@@ -50,7 +44,6 @@ public class LinuxSteamServerSanitizer {
             if (foundSteamclient != null) {
                 PZOServerLogger.info("[Linux Sanitizer] Located steamclient.so at: " + foundSteamclient.getAbsolutePath());
 
-                // 1. Pre-load steamclient.so into process memory so dlopen succeeds immediately
                 try {
                     System.load(foundSteamclient.getAbsolutePath());
                     PZOServerLogger.success("[Linux Sanitizer] Pre-loaded steamclient.so into JVM process memory");
@@ -58,7 +51,7 @@ public class LinuxSteamServerSanitizer {
                     PZOServerLogger.info("[Linux Sanitizer] System.load notice: " + t.getMessage());
                 }
 
-                // 2. Ensure ~/.steam/sdk64/steamclient.so exists (where Steam searches on Linux)
+                // Steam also searches ~/.steam/sdk64/steamclient.so on Linux.
                 java.util.Set<Path> targetDirs = new java.util.LinkedHashSet<>();
                 if (userHome != null && !userHome.isEmpty()) {
                     targetDirs.add(Paths.get(userHome, ".steam", "sdk64"));

--- a/src/com/pzoptimizer/server/PZOServerEntrypoint.java
+++ b/src/com/pzoptimizer/server/PZOServerEntrypoint.java
@@ -3,11 +3,6 @@ package com.pzoptimizer.server;
 import java.io.File;
 import java.lang.reflect.Method;
 
-/**
- * Project Zomboid Build 42 & 41 - Dedicated Server Master Optimization Entrypoint.
- * Bootstraps zero-lag networking, multi-threaded horde simulation, and 24/7 memory stability
- * before handing execution over to zombie.network.GameServer.
- */
 public class PZOServerEntrypoint {
     public static final String SERVER_VERSION = "0.9.6";
 
@@ -27,7 +22,6 @@ public class PZOServerEntrypoint {
 
         long startTime = System.currentTimeMillis();
 
-        // 1. Enforce headless execution for dedicated servers
         try {
             System.setProperty("java.awt.headless", "true");
         } catch (Throwable ignored) {}
@@ -41,7 +35,6 @@ public class PZOServerEntrypoint {
         long maxHeapMB = Runtime.getRuntime().maxMemory() / (1024 * 1024);
         PZOServerLogger.info("Host Server Resources: " + cores + " CPU Cores | Max JVM Heap: " + maxHeapMB + " MB");
 
-        // 1.1. If instrumentation is available, hook bytecode transformers
         if (inst != null) {
             try {
                 com.pzoptimizer.PZOptimAgent.premain(null, inst);
@@ -50,10 +43,8 @@ public class PZOServerEntrypoint {
             }
         }
 
-        // 1.2. Automatic Linux Dedicated Server Steam Native Sanitizer
         LinuxSteamServerSanitizer.sanitize();
 
-        // 1.5. HotSpot JIT & Engine Architecture Tuner
         com.pzoptimizer.HotSpotJITCompilerTuner.tuneRuntimeProperties();
         com.pzoptimizer.EngineFeaturesTuner.initializeEngineFeatures();
         com.pzoptimizer.WorldStreamerBooster.startDaemon();
@@ -66,21 +57,16 @@ public class PZOServerEntrypoint {
         com.pzoptimizer.NativeDirectMemoryPool.initialize();
         com.pzoptimizer.FastBitwiseChunkIndexer.initialize();
 
-        // 2. Initialize Server Network Buffer Pooler
         com.pzoptimizer.PZOEngineBridge.initialize();
         ServerNetworkTuner.apply();
         PZOServerNetGovernor.initialize();
 
-        // 3. Initialize Multi-Threaded Zombie Simulation
         ServerHordeSimEngine.apply();
 
-        // 4. Initialize Zero-Lag World Save & Chunk Stream Booster
         ServerChunkStreamBooster.apply();
 
-        // 5. Check & Support ZombieBuddy Server Coexistence
         checkZombieBuddyServer();
 
-        // 6. Launch Server Telemetry Daemon
         ServerTelemetryBridge.startTelemetryDaemon();
 
         long initDuration = System.currentTimeMillis() - startTime;
@@ -92,7 +78,6 @@ public class PZOServerEntrypoint {
         initServerPipelines(null);
         PZOServerLogger.info("Handing execution over to Project Zomboid Dedicated Server (zombie.network.GameServer)...");
 
-        // 7. Invoke Vanilla GameServer Entrypoint
         try {
             Class<?> targetClass = Class.forName("zombie.network.GameServer");
             Method mainMethod = targetClass.getMethod("main", String[].class);

--- a/src/com/pzoptimizer/server/PZOServerNetGovernor.java
+++ b/src/com/pzoptimizer/server/PZOServerNetGovernor.java
@@ -2,14 +2,6 @@ package com.pzoptimizer.server;
 
 import com.pzoptimizer.PZOLogger;
 
-/**
- * PZO Dedicated Server Network & Packet Pacing Governor.
- * Optimizes multiplayer network throughput, Netty direct byte buffer recycling,
- * and entity sync packet queue pacing on Build 42 dedicated servers.
- * 
- * Prevents network thread GC pauses and eliminates multiplayer vehicle rubberbanding
- * during high-speed map travel.
- */
 public final class PZOServerNetGovernor {
 
     private static volatile boolean active = false;
@@ -19,13 +11,11 @@ public final class PZOServerNetGovernor {
         active = true;
 
         try {
-            // Configure Netty Direct Memory Allocation for Zero-Copy Networking
             System.setProperty("io.netty.allocator.type", "pooled");
             System.setProperty("io.netty.allocator.maxOrder", "9"); // 4MB maximum chunk order
             System.setProperty("io.netty.allocator.pageSize", "8192"); // 8KB aligned pages
             System.setProperty("io.netty.recycler.maxCapacityPerThread", "4096");
 
-            // Tune RakNet / UDP Socket buffer limits
             System.setProperty("zomboid.raknet.max_packet_queue", "16384");
             System.setProperty("zomboid.raknet.split_packet_cache", "true");
 

--- a/src/com/pzoptimizer/server/ServerChunkStreamBooster.java
+++ b/src/com/pzoptimizer/server/ServerChunkStreamBooster.java
@@ -1,13 +1,8 @@
 package com.pzoptimizer.server;
 
-/**
- * Project Zomboid Dedicated Server - Zero-Lag World Save & SQLite Stream Booster.
- * Configures 256KB disk buffer streaming to eliminate world save lag spikes.
- */
 public class ServerChunkStreamBooster {
     public static void apply() {
         try {
-            // 256KB page-aligned buffer chunks for SQLite .db and map_*.bin files
             System.setProperty("pzo.server.stream_buffer_size", "262144");
             System.setProperty("jdk.nio.maxCachedBufferSize", "524288");
             System.setProperty("sun.nio.PageAlignDirectMemory", "true");

--- a/src/com/pzoptimizer/server/ServerHordeSimEngine.java
+++ b/src/com/pzoptimizer/server/ServerHordeSimEngine.java
@@ -2,10 +2,6 @@ package com.pzoptimizer.server;
 
 import java.util.concurrent.ForkJoinPool;
 
-/**
- * Project Zomboid Dedicated Server - Multi-Threaded Zombie Simulation Engine.
- * Distributes zombie pathfinding, migration, and collision checks across all host CPU cores.
- */
 public class ServerHordeSimEngine {
     public static void apply() {
         try {

--- a/src/com/pzoptimizer/server/ServerNetworkTuner.java
+++ b/src/com/pzoptimizer/server/ServerNetworkTuner.java
@@ -1,21 +1,15 @@
 package com.pzoptimizer.server;
 
-/**
- * Project Zomboid Dedicated Server - Zero-Rubberband High-Throughput Network Engine.
- * Configures off-heap direct NIO socket buffer pooling to eliminate multiplayer latency spikes.
- */
 public class ServerNetworkTuner {
     public static void apply() {
         try {
             int cores = Math.max(4, Runtime.getRuntime().availableProcessors());
 
-            // 1. Off-heap Netty direct memory pooling for 10-64+ players
             System.setProperty("io.netty.allocator.type", "pooled");
             System.setProperty("io.netty.allocator.numDirectArenas", String.valueOf(cores));
             System.setProperty("io.netty.allocator.numHeapArenas", String.valueOf(Math.max(2, cores / 2)));
             System.setProperty("io.netty.noPreferDirect", "false");
 
-            // 2. High-capacity datagram sockets for RakNet UDP packet broadcasting
             System.setProperty("sun.net.maxDatagramSockets", "4096");
             System.setProperty("java.net.preferIPv4Stack", "true");
             System.setProperty("sun.net.useExclusiveBind", "true");

--- a/src/com/pzoptimizer/server/ServerTelemetryBridge.java
+++ b/src/com/pzoptimizer/server/ServerTelemetryBridge.java
@@ -9,10 +9,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Project Zomboid Dedicated Server - Live Server Telemetry Bridge.
- * Streams real-time TPS, memory metrics, GC pause latencies, and thread states for server admins and Discord bots.
- */
 public class ServerTelemetryBridge {
     private static final java.util.Set<File> telemetryFiles = java.util.Collections.synchronizedSet(new java.util.LinkedHashSet<>());
 


### PR DESCRIPTION
Many source comments repeat nearby code, make unsupported performance or safety guarantees, or describe behavior that the implementation no longer provides. Remove those claims, feature-pitch headers, decorative banners, and phase/pass narration across the Java sources, native bridge, and installer/packaging scripts.

Keep concise explanations of threading restrictions, bytecode offsets, compatibility workarounds, and updater ordering. Clarify that the telemetry cost coefficients and chunk-time baseline are estimates. Executable code, string literals, runtime messages, vendored miniz sources, and license files are unchanged.

Validation:
- Java/C code-token and string-literal comparison against the base commit passed.
- Python AST comparison passed for the packager and all four embedded installer Python blocks.
- Both shell installers passed `bash -n`.
- The embedded PowerShell installer parsed successfully with identical non-comment tokens; its batch entry point and script marker are preserved.
- `git diff --check` passed.

No game execution or full build was needed for this comment-only change. No tests were added and CI was not awaited.
